### PR TITLE
[feat] 화면 이동 로직 구현 

### DIFF
--- a/DomadoV/DomadoV/App/ContentView.swift
+++ b/DomadoV/DomadoV/App/ContentView.swift
@@ -31,7 +31,10 @@ struct ContentView: View {
             let vm = RideSummaryViewModel()
             RideSummaryView(vm: vm)
                 .onAppear{coordinator.bind(to: vm)}
-            
+        case .history:
+            let vm = RideHistoryViewModel()
+            RideHistoryView(vm: vm)
+                .onAppear{coordinator.bind(to: vm)}
         }
     }
 }

--- a/DomadoV/DomadoV/Coordinator/AppCoordinator .swift
+++ b/DomadoV/DomadoV/Coordinator/AppCoordinator .swift
@@ -39,6 +39,10 @@ class AppCoordinator: ObservableObject{
             currentView = .active
         case .didFinishRide:
             currentView = .summary
+        case .didRequestHistory:
+            currentView = .history
+        case .didReturnToPreparation:
+            currentView = .preparation
         }
     }
     

--- a/DomadoV/DomadoV/Coordinator/AppView.swift
+++ b/DomadoV/DomadoV/Coordinator/AppView.swift
@@ -15,4 +15,6 @@ enum AppView {
     case pause
     /// 주행 종료
     case summary
+    /// 주행 기록
+    case history
 }

--- a/DomadoV/DomadoV/Coordinator/RideEvent.swift
+++ b/DomadoV/DomadoV/Coordinator/RideEvent.swift
@@ -17,4 +17,8 @@ enum RideEvent {
     case didResumeRide
     /// 정지화면 -> 주행완료
     case didFinishRide
+    /// 준비화면 -> 기록화면
+    case didRequestHistory
+    /// 기록화면 -> 준비화면
+    case didReturnToPreparation
 }

--- a/DomadoV/DomadoV/View/RideDetailView.swift
+++ b/DomadoV/DomadoV/View/RideDetailView.swift
@@ -1,0 +1,18 @@
+//
+//  RideDetailView.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/10/24.
+//
+
+import SwiftUI
+
+struct RideDetailView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    RideDetailView()
+}

--- a/DomadoV/DomadoV/View/RideHistoryCell.swift
+++ b/DomadoV/DomadoV/View/RideHistoryCell.swift
@@ -1,0 +1,18 @@
+//
+//  RideHistoryCell.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/10/24.
+//
+
+import SwiftUI
+
+struct RideHistoryCell: View {
+    var body: some View {
+        Text("RIDE HISTORY CELL")
+    }
+}
+
+#Preview {
+    RideHistoryCell()
+}

--- a/DomadoV/DomadoV/View/RideHistoryView.swift
+++ b/DomadoV/DomadoV/View/RideHistoryView.swift
@@ -7,12 +7,29 @@
 
 import SwiftUI
 
+/// 주행 기록 화면
+///
+/// 1. 현재까지의 주행기록을 리스트의 형태로 보여줍니다.
+/// 2. 각 셀을 눌렀을 때 해당 기록에 대한 상세뷰로 이동합니다.
 struct RideHistoryView: View {
     
     @ObservedObject var vm: RideHistoryViewModel
     
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            VStack(spacing: 20){
+                
+                Button {
+                    vm.returnToPreparation()
+                } label: {
+                    Text("주행 준비 화면으로 돌아가기")
+                }
+
+                NavigationLink(destination: RideDetailView()){
+                    RideHistoryCell()
+                }
+            }
+        }
     }
 }
 

--- a/DomadoV/DomadoV/View/RideHistoryView.swift
+++ b/DomadoV/DomadoV/View/RideHistoryView.swift
@@ -1,0 +1,21 @@
+//
+//  RideHistoryView.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/10/24.
+//
+
+import SwiftUI
+
+struct RideHistoryView: View {
+    
+    @ObservedObject var vm: RideHistoryViewModel
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    RideHistoryView(vm: RideHistoryViewModel())
+}

--- a/DomadoV/DomadoV/View/RidePreparationView.swift
+++ b/DomadoV/DomadoV/View/RidePreparationView.swift
@@ -27,6 +27,13 @@ struct RidePreparationView: View {
             } label: {
                 Text("시작 버튼")
             }
+            
+            Button {
+                vm.showHistory()
+            } label: {
+                Text("주행 기록 보기 버튼")
+            }
+
 
             
         }

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -19,7 +19,15 @@ struct RideSummaryView: View {
     @ObservedObject var vm: RideSummaryViewModel
     
     var body: some View {
-        Text("화이팅")
+       
+        VStack(spacing: 20){
+            
+            Button {
+                vm.dismissSummary()
+            } label: {
+                Text("주행 준비 화면으로 돌아가기")
+            }
+        }
     }
 }
 

--- a/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
@@ -12,9 +12,9 @@ class RideHistoryViewModel: ObservableObject, RideEventPublishable {
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
     
-    
-    
-    
-    
-    
+    /// 주행준비화면으로 돌아가기
+    func returnToPreparation() {
+        rideEventSubject.send(.didReturnToPreparation)
+    }
+
 }

--- a/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  RideHistoryViewModel.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/10/24.
+//
+
+import Combine
+
+class RideHistoryViewModel: ObservableObject, RideEventPublishable {
+    
+    /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
+    let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    
+    
+    
+    
+    
+    
+}

--- a/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
@@ -17,4 +17,9 @@ class RidePreparationViewModel: ObservableObject, RideEventPublishable {
     func startRide() {
         rideEventSubject.send(.didStartRide)
     }
+    
+    /// 주행기록을 보여줍니다.
+    func showHistory() {
+        rideEventSubject.send(.didRequestHistory)
+    }
 }

--- a/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
@@ -12,4 +12,9 @@ class RideSummaryViewModel: ObservableObject, RideEventPublishable {
     
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    
+    /// 준비화면으로 돌아가기 
+    func dismissSummary() {
+        rideEventSubject.send(.didReturnToPreparation)
+    }
 }


### PR DESCRIPTION
```mermaid
graph TD
    A[ContentView] -->|Uses| B[AppCoordinator]
    B -->|Manages| C[currentView]
    B -->|Subscribes to| D[RideEventPublishable]
    
    D -->|Implemented by| E[RidePreparationViewModel]
    D -->|Implemented by| F[ActiveRideViewModel]
    D -->|Implemented by| G[PauseRideViewModel]
    D -->|Implemented by| H[RideSummaryViewModel]
    D -->|Implemented by| N[RideHistoryViewModel]
    
    E -->|Sends didStartRide/didRequestHistory| I[RideEvent]
    F -->|Sends didPauseRide| I
    G -->|Sends didResumeRide/didFinishRide| I
    H -->|Sends didDismissSummary| I
    N -->|Sends didReturnToPreparation| I
    
    I -->|Triggers| B
    
    C -->|Shows| J[RidePreparationView]
    C -->|Shows| K[ActiveRideView]
    C -->|Shows| L[PauseRideView]
    C -->|Shows| M[RideSummaryView]
    C -->|Shows| O[RideHistoryView]
    
    J -.->|User Action| E
    K -.->|User Action| F
    L -.->|User Action| G
    M -.->|User Action| H
    O -.->|User Action| N
    
    O -->|NavigationLink| P[RideDetailView]
    O -.->|Back Button| N
    
    style A fill:#f9f,stroke:#333,stroke-width:2px
    style B fill:#bbf,stroke:#333,stroke-width:2px
    style I fill:#fbb,stroke:#333,stroke-width:2px
    style O fill:#bfb,stroke:#333,stroke-width:2px
    style P fill:#bfb,stroke:#333,stroke-width:2px
```


## 🔴 변경 사항 (What)

1. RidePreparationView 수정
   - "주행 기록 보기" 버튼 추가
   - RidePreparationViewModel에 showHistory() 메서드 구현

2. RideHistoryView 및 RideHistoryViewModel 구현
   - 주행 기록 목록을 표시하는 RideHistoryView 생성
   - RideHistoryViewModel 구현 및 RideEventPublishable 프로토콜 채택
   - NavigationLink를 사용하여 RideDetailView로 이동하는 기능 구현

3. RideSummaryView 수정
   - 오른쪽 상단에 X 버튼 추가
   - 화면을 아래로 스와이프하여 닫을 수 있는 제스처 구현
   - 화면이 닫힐 때 아래로 내려가는 애니메이션 효과 추가
   - RideSummaryViewModel에 dismissSummary() 메서드 구현

4. AppView enum 수정
   - history 케이스 추가

5. RideEvent enum 수정
   - didRequestHistory, didDismissSummary, didReturnToPreparation 이벤트 추가

6. AppCoordinator 수정
   - handleRideEvent 메서드에 새로운 이벤트 처리 로직 추가
   - currentView 상태 관리 로직 업데이트

## 🟠 변경 이유 (Why)

1. 사용자가 주행 준비 화면에서 과거의 주행 기록을 쉽게 확인할 수 있도록 하기 위함
2. 주행 종료 후 사용자가 자연스럽게 새로운 주행을 시작할 수 있도록 사용자 경험을 개선하기 위함
3. 앱의 주요 화면 간 전환을 일관된 방식으로 관리하여 코드의 유지보수성과 확장성을 향상시키기 위함
4. 세부적인 내비게이션(주행 기록 목록에서 상세 정보로의 이동)을 SwiftUI의 기본 내비게이션 시스템과 통합하여 사용자에게 익숙한 인터페이스를 제공하기 위함

## 🟢 추가 노트 (Additional Notes)

- 이 변경으로 인해 앱의 전체적인 네비게이션 흐름이 개선되었습니다. 사용자는 주행 준비 -> 주행 기록 확인 -> 주행 준비로의 순환적 흐름을 경험할 수 있게 되었습니다.
- RideHistoryView에서 RideDetailView로의 이동은 NavigationLink를 사용하여 구현되었습니다. 이는 SwiftUI의 내비게이션 스택을 활용하여 자연스러운 화면 전환과 뒤로 가기 기능을 제공합니다.
- AppCoordinator를 통한 주요 화면 전환과 NavigationLink를 통한 세부 화면 이동을 결합하여, 앱의 전반적인 구조를 유지하면서도 세부적인 내비게이션을 자연스럽게 처리할 수 있게 되었습니다.
- 향후 새로운 화면이나 기능을 추가할 때, 이 구조를 따라 쉽게 확장할 수 있습니다.

이 Pull Request를 통해 앱의 사용성과 코드 구조가 크게 개선되었습니다. 리뷰 후 피드백이 있다면 말씀해 주시기 바랍니다.