### PR TITLE
[feat] LocationManager 권한 발행자 및 RideSession 메서드 추가

### DIFF
--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -15,7 +15,12 @@ class RideSession {
     @Published private(set) var currentSpeed: Double = 0
     @Published private(set) var totalDistance: Double = 0
     @Published private(set) var totalRideTime: TimeInterval = 0
+    @Published private(set) var currentLocation: LocationData?
     
+    @Published private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
+    @Published private(set) var locationPermissionDenied: Bool = false
+    
+    private(set) var state: AppView = .preparation
     private(set) var startTime: Date?
     private(set) var endTime: Date?
     private(set) var locations: [LocationData] = []
@@ -28,46 +33,156 @@ class RideSession {
     private var speedDistribution = SpeedDistribution()
     private var previousLocation: LocationData?
     private var cancellables = Set<AnyCancellable>()
+    private let processingQueue = DispatchQueue(label: "com.domadoV.rideProcessing", qos: .userInitiated)
+    
     
     init(targetSpeedRange: ClosedRange<Double>) {
         self.targetSpeedRange = targetSpeedRange
+        setupLocationSubscription()
+        setupAuthorizationSubscription()
+    }
+    
+    private func setupAuthorizationSubscription() {
+        LocationManager.shared.authorizationPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.authorizationStatus = status
+                self?.locationPermissionDenied = (status == .denied || status == .restricted)
+            }
+            .store(in: &cancellables)
+    }
+    
+    
+    private func setupLocationSubscription() {
+        LocationManager.shared.locationSubject
+            .receive(on: processingQueue)
+            .sink { [weak self] locationData in
+                self?.handleLocationUpdate(LocationData(location: locationData))
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleLocationUpdate(_ location: LocationData) {
+         switch state {
+         case .preparation:
+             updateUserNewLocation(location)
+         case .active:
+             handleNewLocation(location)
+         case .pause, .summary, .history:
+             break
+         }
+     }
+    
+    /// 주행준비
+    func prepare() -> AnyPublisher<Bool, Never> {
+        state = .preparation
+        return Future<Bool, Never> { promise in
+                    switch self.authorizationStatus {
+                    case .notDetermined:
+                        LocationManager.shared.requestLocationAuthorization()
+                        self.waitForAuthorizationStatus()
+                            .sink { status in
+                                let isAuthorized = (status == .authorizedWhenInUse || status == .authorizedAlways)
+                                self.locationPermissionDenied = !isAuthorized
+                                promise(.success(isAuthorized))
+                            }
+                            .store(in: &self.cancellables)
+                    case .restricted, .denied:
+                        self.locationPermissionDenied = true
+                        promise(.success(false))
+                    case .authorizedWhenInUse, .authorizedAlways:
+                        LocationManager.shared.startUpdatingLocation()
+                        promise(.success(true))
+                    @unknown default:
+                        promise(.success(false))
+                    }
+                }.eraseToAnyPublisher()
+    }
+    
+    private func waitForAuthorizationStatus() -> AnyPublisher<CLAuthorizationStatus, Never> {
+        LocationManager.shared.authorizationPublisher
+            .filter { $0 != .notDetermined }
+            .first()
+            .eraseToAnyPublisher()
     }
     
     /// 주행시작
     func start() {
+        guard state == .preparation else { return }
         startTime = Date()
-        // TODO: LocationManager 위치정보 업데이트 시작
-        // TODO: 업데이트되는 위치정보 구독하기
+        state = .active
     }
 
     /// 주행 정지
     func pause() {
+        guard state == .active else { return }
+        state = .pause
         currentRestPeriod = RestPeriod(startTime: Date())
-        // TODO: LocationManagaer 위치정보 업데이트 중지
-
+        LocationManager.shared.stopUpdatingLocation()
     }
 
     /// 주행 재개
     func resume() {
+        guard state == .pause else { return }
         if var restPeriod = currentRestPeriod {
             restPeriod.endTime = Date()
             restPeriods.append(restPeriod)
             totalRestTime += restPeriod.duration
             currentRestPeriod = nil
         }
-        // TODO: LocationManager 위치정보 업데이트 시작
+        state = .active
+        LocationManager.shared.startUpdatingLocation()
     }
 
     /// 주행 종료
     func stop() {
+        guard state == .pause else { return }
         endTime = Date()
-        // TODO: LocationManagaer 위치정보 업데이트 중지
-        cancellables.removeAll()
+        state = .summary
+        LocationManager.shared.stopUpdatingLocation()
+    }
+    
+    /// 주행중이 아닐때 사용자 위치 정보 업데이트
+    private func updateUserNewLocation(_ locationData: LocationData){
+        DispatchQueue.main.async { self.currentLocation = locationData }
     }
 
-    /// 구독한  LocationData를 사용해 RideSession의 각 프로퍼티 값 업데이트
+    /// 주행중일 때 주행 정보 업데이트
     private func handleNewLocation(_ locationData: LocationData) {
-
+        locations.append(locationData)
+      
+        // 누적 시간 계산
+        let newTotalRideTime = locationData.timestamp.timeIntervalSince(startTime!) - totalRestTime
+        
+        // 거리 및 속도 계산
+        var newTotalDistance = totalDistance
+        var newCurrentSpeed = locationData.speed
+        
+        if let previousLocation = previousLocation {
+            let distance = calculateDistance(from: previousLocation, to: locationData)
+            newTotalDistance += distance
+            
+            // locationData.speed가 유효하지 않은 경우 (-1.0), 계산된 속도 사용
+            if newCurrentSpeed < 0 {
+                let timeDifference = locationData.timestamp.timeIntervalSince(previousLocation.timestamp)
+                newCurrentSpeed = timeDifference > 0 ? distance / timeDifference : 0
+            }
+            
+            // 속도 분포 업데이트
+            let deltaTime = locationData.timestamp.timeIntervalSince(previousLocation.timestamp)
+            speedDistribution.update(with: newCurrentSpeed, targetRange: targetSpeedRange, deltaTime: deltaTime)
+        }
+        
+        // 메인 스레드에서 UI 업데이트
+        DispatchQueue.main.async {
+            self.totalRideTime = newTotalRideTime
+            self.totalDistance = newTotalDistance
+            self.currentSpeed = newCurrentSpeed
+        }
+        
+        // 현재 위치를 이전 위치로 저장
+        previousLocation = locationData
+        
     }
 
     private func calculateDistance(from: LocationData, to: LocationData) -> Double {


### PR DESCRIPTION
## 🔴 변경 사항 (What)

1. LocationManager 클래스:
   - `authorizationPublisher`를 추가하여 위치 권한 상태 변경사항을 발행


2. RideSession 클래스:
   - 주행 관련 상태 및  위치 권한과 관련된 프로퍼티 추가 (state, authorizationStatus, locationPermissionDenied)
   - 주행 세션 관리를 위한 메서드 구현 (prepare(), start(), pause(), resume(), stop())
   - 위치 업데이트 처리 로직 구현 (handleLocationUpdate(), handleNewLocation())
   - 권한 상태 구독 및 관리 로직 추가

## 🟠 변경 이유 (Why)

1. 위치 권한 관리 개선:
   - 사용자의 위치 권한 상태를 실시간으로 추적하고 대응하기 위해
   - 앱의 다른 부분에서 권한 상태 변경에 쉽게 반응할 수 있도록 함

2. 주행 세션 관리 기능 구현:
   - 사용자의 주행 데이터를 정확하게 추적하고 관리하기 위해
   - 주행 시작, 일시 정지, 재개, 종료 등의 기능을 제공하여 사용자 경험 향상
   - 지도상의 사용자 위치정보를 표시하기 위해 
   - 실시간 위치 데이터를 기반으로 속도, 거리 등의 정보를 계산하고 업데이트하기 위해

## 🟡 테스트 방법 (How to Test)

1. LocationManager 테스트:
   - 앱 실행 시 초기 권한 상태 확인
   - 권한 요청 후 상태 변경 확인
   - 권한 변경 시 `authorizationPublisher`를 통해 새로운 상태가 발행되는지 확인

2. RideSession 테스트:
   - `prepare()` 메서드 호출 후 권한 상태에 따른 동작 확인
   - 주행 시작, 일시 정지, 재개, 종료 기능 테스트
   - 위치 업데이트에 따른 속도, 거리 계산 정확성 확인
   - 권한 상태 변경에 따른 UI 업데이트 확인

## 🟢 추가 노트 (Additional Notes)

- LocationManager와 RideSession 간의 의존성에 주의해야 합니다. LocationManager의 변경사항이 RideSession의 동작에 영향을 줄 수 있습니다.
- 실제 기기에서 테스트하여 GPS 데이터의 정확성과 배터리 소모를 확인해야 합니다.
- 향후 개선사항: 
  - 백그라운드 위치 추적 기능 추가 고려
  - 오프라인 상태에서의 데이터 저장 및 동기화 방법 구현 필요
