### PR TITLE
[feat] RideSession 관리 Flow 구현

### DIFF
--- a/DomadoV/DomadoV/App/ContentView.swift
+++ b/DomadoV/DomadoV/App/ContentView.swift
@@ -16,21 +16,30 @@ struct ContentView: View {
         
         switch coordinator.currentView {
         case .preparation:
-            let vm = RidePreparationViewModel()
+            let rideSession = RideSession()
+            let vm = RidePreparationViewModel(rideSession: rideSession)
             RidePreparationView(vm: vm)
-                .onAppear{coordinator.bind(to: vm)}
+                .onAppear{
+                    coordinator.rideSession = rideSession
+                    coordinator.bind(to: vm)}
         case .active:
-            let vm = ActiveRideViewModel()
-            ActiveRideView(vm: vm)
-                .onAppear{coordinator.bind(to: vm)}
+            if let rideSession = coordinator.rideSession {
+                let vm = ActiveRideViewModel(rideSession: rideSession)
+                ActiveRideView(vm: vm)
+                    .onAppear{coordinator.bind(to: vm)}
+            }
         case .pause:
-            let vm = PauseRideViewModel()
-            PauseRideView(vm: vm)
-                .onAppear{coordinator.bind(to: vm)}
+            if let rideSession = coordinator.rideSession{
+                let vm = PauseRideViewModel(rideSession: rideSession)
+                PauseRideView(vm: vm)
+                    .onAppear{coordinator.bind(to: vm)}
+            }
         case .summary:
-            let vm = RideSummaryViewModel()
-            RideSummaryView(vm: vm)
-                .onAppear{coordinator.bind(to: vm)}
+            if let rideSession = coordinator.rideSession{
+                let vm = RideSummaryViewModel(rideSession: rideSession)
+                RideSummaryView(vm: vm)
+                    .onAppear{coordinator.bind(to: vm)}
+            }
         case .history:
             let vm = RideHistoryViewModel()
             RideHistoryView(vm: vm)

--- a/DomadoV/DomadoV/Coordinator/AppCoordinator .swift
+++ b/DomadoV/DomadoV/Coordinator/AppCoordinator .swift
@@ -15,6 +15,7 @@ class AppCoordinator: ObservableObject{
     @Published var currentView: AppView = .preparation
     /// 현재 구독을 관리합니다.
     private var currentSubscription: AnyCancellable?
+    var rideSession: RideSession!
     
     /// 현재 view에 대한 viewModel의 publisher를 구독합니다.
     func bind(to viewModel: RideEventPublishable) {

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -29,15 +29,14 @@ class RideSession {
     private(set) var averageSpeed: Double = 0
     
     private var currentRestPeriod: RestPeriod?
-    private var targetSpeedRange: ClosedRange<Double>
+    private var targetSpeedRange: ClosedRange<Double> = 0...15
     private var speedDistribution = SpeedDistribution()
     private var previousLocation: LocationData?
     private var cancellables = Set<AnyCancellable>()
     private let processingQueue = DispatchQueue(label: "com.domadoV.rideProcessing", qos: .userInitiated)
     
     
-    init(targetSpeedRange: ClosedRange<Double>) {
-        self.targetSpeedRange = targetSpeedRange
+    init() {
         setupLocationSubscription()
         setupAuthorizationSubscription()
     }

--- a/DomadoV/DomadoV/View/ActiveRideView.swift
+++ b/DomadoV/DomadoV/View/ActiveRideView.swift
@@ -44,5 +44,5 @@ struct ActiveRideView: View {
 }
 
 #Preview {
-    ActiveRideView(vm: ActiveRideViewModel())
+    ActiveRideView(vm: ActiveRideViewModel(rideSession: RideSession()))
 }

--- a/DomadoV/DomadoV/View/PauseRideView.swift
+++ b/DomadoV/DomadoV/View/PauseRideView.swift
@@ -45,5 +45,5 @@ struct PauseRideView: View {
 }
 
 #Preview {
-    PauseRideView(vm: PauseRideViewModel())
+    PauseRideView(vm: PauseRideViewModel(rideSession: RideSession()))
 }

--- a/DomadoV/DomadoV/View/RidePreparationView.swift
+++ b/DomadoV/DomadoV/View/RidePreparationView.swift
@@ -41,5 +41,5 @@ struct RidePreparationView: View {
 }
 
 #Preview {
-    RidePreparationView(vm: RidePreparationViewModel())
+    RidePreparationView(vm: RidePreparationViewModel(rideSession: RideSession()))
 }

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -32,5 +32,5 @@ struct RideSummaryView: View {
 }
 
 #Preview {
-    RideSummaryView(vm: RideSummaryViewModel())
+    RideSummaryView(vm: RideSummaryViewModel(rideSession: RideSession()))
 }

--- a/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
@@ -10,8 +10,13 @@ import Combine
 /// 주행화면에 대한 정보와 동작을 관리합니다. 
 class ActiveRideViewModel: ObservableObject, RideEventPublishable {
     
-    /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다. 
+    let rideSession: RideSession
+    /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    
+    init(rideSession: RideSession) {
+        self.rideSession = rideSession
+    }
     
     func pauseRide() {
         rideEventSubject.send(.didPauseRide)

--- a/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
@@ -10,8 +10,13 @@ import Combine
 /// 주행정지 화면에 대한 정보와 동작을 관리합니다. 
 class PauseRideViewModel: ObservableObject, RideEventPublishable {
     
-    /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다. 
+    let rideSession: RideSession
+    /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    
+    init(rideSession: RideSession) {
+        self.rideSession = rideSession
+    }
     
     func resumeRide(){
         rideEventSubject.send(.didResumeRide)

--- a/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
@@ -10,8 +10,13 @@ import Combine
 /// 주행시작화면에 대한 정보 및 동작을 관리합니다.
 class RidePreparationViewModel: ObservableObject, RideEventPublishable {
     
-    /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다. 
+    let rideSession: RideSession
+    /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    
+    init(rideSession: RideSession) {
+        self.rideSession = rideSession
+    }
     
     /// 주행을 시작합니다.
     func startRide() {

--- a/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
@@ -10,8 +10,13 @@ import Combine
 /// 주행종료화면에 대한 정보와 동작을 관리합니다.
 class RideSummaryViewModel: ObservableObject, RideEventPublishable {
     
+    let rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    
+    init(rideSession: RideSession) {
+        self.rideSession = rideSession
+    }
     
     /// 준비화면으로 돌아가기 
     func dismissSummary() {


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `AppCoordinator`에 `RideSession` 프로퍼티 추가 
- `RidePreparationViewModel`, `PauseRideViewModel`, `ActiveRideViewModel`, `RideSummaryViewModel` 에 `RideSesion` 프로퍼티 및 생성자 추가 
- `RideSession`의 `targetSpeedRange` 기본값 할당 및 생성자에서 제거 
-`ContentView`에서 `RideSession` 초기화 및 각 ViewModel에 주입  

## 🟠 변경 이유 (Why)
- `AppCoordinator`에서 `RideSession`을 관리하게 함으로써 하나의 주행에 대한 일관된 기록이 가능합니다. 
- `ContentView`에서 `AppCoordinator`로부터 `RideSession`을 받아 각 ViewModel을 초기화하면서 주행시 각 화면에 대한 로직을 한 곳에 관리 가능합니다. 

## 🟢 추가 노트 (Additional Notes)
- `RideSession`의 `targetSpeedRange`에 기본값을 줌으로써 주행 시작전 사용자가 설정한 속도 범위로 `RideSession`을 업데이트 해주어야합니다. 

