### PR TITLE
[feat] 주행 준비화면 동작 구현 

### DIFF
--- a/DomadoV/DomadoV.xcodeproj/project.pbxproj
+++ b/DomadoV/DomadoV.xcodeproj/project.pbxproj
@@ -412,8 +412,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DomadoV/Info.plist;
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "라이딩 정보를 관리하기 위해서는 위치 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -448,8 +448,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DomadoV/Info.plist;
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "라이딩 정보를 관리하기 위해서는 위치 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -15,8 +15,6 @@ class RideSession {
     @Published private(set) var currentSpeed: Double = 0
     @Published private(set) var totalDistance: Double = 0
     @Published private(set) var totalRideTime: TimeInterval = 0
-    @Published private(set) var currentLocation: LocationData?
-    
     @Published private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
     @Published private(set) var locationPermissionDenied: Bool = false
     
@@ -51,26 +49,14 @@ class RideSession {
             .store(in: &cancellables)
     }
     
-    
     private func setupLocationSubscription() {
         LocationManager.shared.locationSubject
             .receive(on: processingQueue)
             .sink { [weak self] locationData in
-                self?.handleLocationUpdate(LocationData(location: locationData))
+                self?.handleNewLocation(LocationData(location: locationData))
             }
             .store(in: &cancellables)
     }
-    
-    private func handleLocationUpdate(_ location: LocationData) {
-         switch state {
-         case .preparation:
-             updateUserNewLocation(location)
-         case .active:
-             handleNewLocation(location)
-         case .pause, .summary, .history:
-             break
-         }
-     }
     
     /// 주행준비
     func prepare() -> AnyPublisher<Bool, Never> {
@@ -141,11 +127,6 @@ class RideSession {
         LocationManager.shared.stopUpdatingLocation()
     }
     
-    /// 주행중이 아닐때 사용자 위치 정보 업데이트
-    private func updateUserNewLocation(_ locationData: LocationData){
-        DispatchQueue.main.async { self.currentLocation = locationData }
-    }
-
     /// 주행중일 때 주행 정보 업데이트
     private func handleNewLocation(_ locationData: LocationData) {
         locations.append(locationData)

--- a/DomadoV/DomadoV/View/RidePreparationView.swift
+++ b/DomadoV/DomadoV/View/RidePreparationView.swift
@@ -5,6 +5,7 @@
 //  Created by 이종선 on 10/8/24.
 //
 
+import MapKit
 import SwiftUI
 
 /// 주행 시작전 화면
@@ -17,10 +18,21 @@ struct RidePreparationView: View {
     @ObservedObject var vm: RidePreparationViewModel
     
     var body: some View {
+        
         VStack(spacing: 20){
+            
+            if let region = vm.mapRegion {
+                Map(coordinateRegion: .constant(region), showsUserLocation: true)
+                    .edgesIgnoringSafeArea(.all)
+            } else {
+                Color.black
+                    .edgesIgnoringSafeArea(.all)
+                Text("위치를 불러오는 중...")
+                    .foregroundColor(.white)
+            }
+            
             Text("주행 속도 범위 입력받는 arc 모양 Slider")
             
-            Text("지도상의 현재 사용자 위치")
             
             Button {
                 vm.startRide()
@@ -34,8 +46,6 @@ struct RidePreparationView: View {
                 Text("주행 기록 보기 버튼")
             }
 
-
-            
         }
     }
 }

--- a/DomadoV/DomadoV/View/RidePreparationView.swift
+++ b/DomadoV/DomadoV/View/RidePreparationView.swift
@@ -16,23 +16,20 @@ import SwiftUI
 struct RidePreparationView: View {
     
     @ObservedObject var vm: RidePreparationViewModel
+    @State private var position: MapCameraPosition = .userLocation(fallback: .automatic)
     
     var body: some View {
         
         VStack(spacing: 20){
             
-            if let region = vm.mapRegion {
-                Map(coordinateRegion: .constant(region), showsUserLocation: true)
-                    .edgesIgnoringSafeArea(.all)
-            } else {
-                Color.black
-                    .edgesIgnoringSafeArea(.all)
-                Text("위치를 불러오는 중...")
-                    .foregroundColor(.white)
+            Map(position: $position) {
+                UserAnnotation()
             }
+            .mapStyle(.standard)
+            .edgesIgnoringSafeArea(.all)
+            .frame(height: 300)
             
             Text("주행 속도 범위 입력받는 arc 모양 Slider")
-            
             
             Button {
                 vm.startRide()
@@ -45,7 +42,22 @@ struct RidePreparationView: View {
             } label: {
                 Text("주행 기록 보기 버튼")
             }
-
+            
+            Spacer()
+            
+        }
+        .onAppear {
+            vm.prepareRide()
+        }
+        .alert(isPresented: $vm.showLocationPermissionAlert) {
+            Alert(
+                title: Text("위치 권한 필요"),
+                message: Text("이 앱은 위치 정보를 사용하여 주행을 기록합니다. 설정에서 위치 권한을 허용해주세요."),
+                primaryButton: .default(Text("설정으로 이동")) {
+                    vm.openSystemSettings()
+                },
+                secondaryButton: .cancel(Text("취소"))
+            )
         }
     }
 }

--- a/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
@@ -6,20 +6,99 @@
 //
 
 import Combine
+import CoreLocation
+import SwiftUI
+import MapKit
 
 /// 주행시작화면에 대한 정보 및 동작을 관리합니다.
 class RidePreparationViewModel: ObservableObject, RideEventPublishable {
     
-    let rideSession: RideSession
+    /// 시스템 설정에서의 위치 권한에 대한 Alert 제어
+    @Published var showLocationPermissionAlert = false
+    /// 사용자 위치 권한 상태
+    @Published var isLocationPermissionGranted = false
+    /// 사용자 현재 위치
+    @Published var mapRegion: MKCoordinateRegion?
+    
+    private let rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    private var cancellables = Set<AnyCancellable>()
     
     init(rideSession: RideSession) {
         self.rideSession = rideSession
+        setupSubscriptions()
+    }
+    
+    func prepareRide() {
+        rideSession.prepare()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isAuthorized in
+                if !isAuthorized {
+                    self?.showLocationPermissionAlert = true
+                }
+                // 권한이 허용된 경우의 추가 로직
+            }
+            .store(in: &cancellables)
+    }
+
+    private func setupSubscriptions() {
+        rideSession.$authorizationStatus
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.isLocationPermissionGranted = (status == .authorizedWhenInUse || status == .authorizedAlways)
+                self?.handleAuthorizationStatusChange(status)
+            }
+            .store(in: &cancellables)
+        
+        rideSession.$currentLocation
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] locationData in
+                if let currentLocation = locationData?.coordinate{
+                    self?.updateMapRegion(with: currentLocation)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func updateMapRegion(with coordinate: CLLocationCoordinate2D) {
+        mapRegion = MKCoordinateRegion(
+            center: coordinate,
+            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+        )
+    }
+    
+    private func handleAuthorizationStatusChange(_ status: CLAuthorizationStatus) {
+        switch status {
+        case .notDetermined:
+            break
+        case .restricted, .denied:
+            showLocationPermissionAlert = true
+        case .authorizedWhenInUse, .authorizedAlways:
+            showLocationPermissionAlert = false
+        @unknown default:
+            break
+        }
+    }
+    
+    // 시스템 설정으로 이동하는 메서드
+    func openSystemSettings() {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        
+        if UIApplication.shared.canOpenURL(settingsUrl) {
+            UIApplication.shared.open(settingsUrl)
+        }
     }
     
     /// 주행을 시작합니다.
+    /// 지정한 속도 범위 보내기
     func startRide() {
+        if !isLocationPermissionGranted {
+            showLocationPermissionAlert = true
+            return
+        }
         rideEventSubject.send(.didStartRide)
     }
     


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- 위치 권한 요청 메시지 추가 
- `RideSession`에서 사용자 현재 위치 프로퍼티 제거 
- `RidePreparationViewModel `에서 위치 권한 체크 및 alert 동작을 위한 프로퍼티 추가 
- `RidePreparationView`에서 MapKit을 이용 사용자 현재 위치 표시
- `onAppear`를 이용해 주행뷰에서 사용자 위치권한 체크 
- `alert`를 이용해 위치 권한 없을시 시스템 설정으로 위치 권한 설정 

## 🟠 변경 이유 (Why)
- 주행 시작전 사용자의 위치 권한을 확인합니다.
- 사용자의 현재 위치를 지도상에 표시함으로써 사용자가 기기의 GPS 상태에 대한 인지 하도록 합니다. 


## 🟢 추가 노트 (Additional Notes)
- viewModel에 MapKit에 대한 의존성을 제거하기 위해 `position` 프로퍼티는 View에서 직접 관리하도록 했습니다. 
-  iOS 17이상을 지원하므로 MapKit을 이용 사용자 현재 위치를 표시합니다. 따라서 사용자의 현재 위치 정보를 직접 관리하지 않습니다. ( RideSession 및 PrearationViewModel에서 사용자 현재 위치 발행 및 구독 흐름을 제거했습니다. )
- 향후 17 미만 버전에 대한 지원이 필요한 경우 8d5a026 커밋을 참조하여 사용자 위치정보를 직접 관리할 수 있습니다. 

