### PR TITLE
[feat] 주행중 화면 업데이트 및 동작 로직 구현 

### DIFF
--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -156,7 +156,7 @@ class RideSession {
         
         // 거리 및 속도 계산
         var newTotalDistance = totalDistance
-        var newCurrentSpeed = locationData.speed
+        var newCurrentSpeed = locationData.speed * 3.6 // m/s -> km/h (단위변환)
         
         if let previousLocation = previousLocation {
             let distance = calculateDistance(from: previousLocation, to: locationData)

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -32,7 +32,7 @@ class RideSession {
     private var previousLocation: LocationData?
     private var cancellables = Set<AnyCancellable>()
     private let processingQueue = DispatchQueue(label: "com.domadoV.rideProcessing", qos: .userInitiated)
-    
+    private var timer: Timer?
     
     init() {
         setupLocationSubscription()
@@ -92,10 +92,13 @@ class RideSession {
     }
     
     /// 주행시작
-    func start() {
+    func start(settedtargetSpeedRange: ClosedRange<Double>) {
         guard state == .preparation else { return }
+        targetSpeedRange = settedtargetSpeedRange
         startTime = Date()
         state = .active
+        startTimer()
+        LocationManager.shared.startUpdatingLocation()
     }
 
     /// 주행 정지
@@ -104,6 +107,7 @@ class RideSession {
         state = .pause
         currentRestPeriod = RestPeriod(startTime: Date())
         LocationManager.shared.stopUpdatingLocation()
+        stopTimer()
     }
 
     /// 주행 재개
@@ -117,6 +121,7 @@ class RideSession {
         }
         state = .active
         LocationManager.shared.startUpdatingLocation()
+        startTimer()
     }
 
     /// 주행 종료
@@ -125,14 +130,29 @@ class RideSession {
         endTime = Date()
         state = .summary
         LocationManager.shared.stopUpdatingLocation()
+        stopTimer()
+    }
+    
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.updateTotalRideTime()
+        }
+    }
+    
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    private func updateTotalRideTime() {
+        guard let startTime = startTime else { return }
+        let currentTime = Date()
+        totalRideTime = currentTime.timeIntervalSince(startTime) - totalRestTime
     }
     
     /// 주행중일 때 주행 정보 업데이트
     private func handleNewLocation(_ locationData: LocationData) {
         locations.append(locationData)
-      
-        // 누적 시간 계산
-        let newTotalRideTime = locationData.timestamp.timeIntervalSince(startTime!) - totalRestTime
         
         // 거리 및 속도 계산
         var newTotalDistance = totalDistance
@@ -155,9 +175,8 @@ class RideSession {
         
         // 메인 스레드에서 UI 업데이트
         DispatchQueue.main.async {
-            self.totalRideTime = newTotalRideTime
             self.totalDistance = newTotalDistance
-            self.currentSpeed = newCurrentSpeed
+            self.currentSpeed = max(newCurrentSpeed, 0)
         }
         
         // 현재 위치를 이전 위치로 저장

--- a/DomadoV/DomadoV/View/ActiveRideView.swift
+++ b/DomadoV/DomadoV/View/ActiveRideView.swift
@@ -18,27 +18,74 @@ struct ActiveRideView: View {
     @ObservedObject var vm: ActiveRideViewModel
     
     var body: some View {
-        ZStack{
-            /// 배경색
-            Color.yellow.ignoresSafeArea()
+        ZStack {
+            Color.black.edgesIgnoringSafeArea(.all)
             
-            VStack(spacing: 20){
-                HStack{
-                    Text("거리")
-                    
-                    Text("시간")
+            VStack(spacing: 30) {
+                speedometer
+                
+                HStack(spacing: 20) {
+                    distanceView
+                    Divider().background(Color.white)
+                    timeView
                 }
                 
-                Text("현재 속도")
+                Spacer()
                 
-                Button {
-                    vm.pauseRide()
-                } label: {
-                    Text("일시정지버튼")
-                }
-                
-                
+                pauseButton
             }
+            .padding()
+        }
+    }
+    
+    private var speedometer: some View {
+        VStack {
+            Text("Current Speed")
+                .font(.headline)
+                .foregroundColor(.white)
+            
+            Text(vm.formattedCurrentSpeed())
+                .font(.system(size: 64, weight: .bold, design: .rounded))
+                .foregroundColor(.green)
+        }
+    }
+    
+    private var distanceView: some View {
+        VStack {
+            Text("Distance")
+                .font(.subheadline)
+                .foregroundColor(.white)
+            
+            Text(vm.formattedTotalDistance())
+                .font(.title2)
+                .fontWeight(.semibold)
+                .foregroundColor(.white)
+        }
+    }
+    
+    private var timeView: some View {
+        VStack {
+            Text("Time")
+                .font(.subheadline)
+                .foregroundColor(.white)
+            
+            Text(vm.formattedTotalRideTime())
+                .font(.title2)
+                .fontWeight(.semibold)
+                .foregroundColor(.white)
+        }
+    }
+    
+    private var pauseButton: some View {
+        Button(action: {
+            vm.pauseRide()
+        }) {
+            Text("Pause")
+                .font(.headline)
+                .foregroundColor(.black)
+                .padding()
+                .background(Color.yellow)
+                .cornerRadius(10)
         }
     }
 }

--- a/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
@@ -6,20 +6,69 @@
 //
 
 import Combine
+import Foundation
 
 /// 주행화면에 대한 정보와 동작을 관리합니다. 
 class ActiveRideViewModel: ObservableObject, RideEventPublishable {
     
-    let rideSession: RideSession
+    @Published var totalRideTime: TimeInterval = 0
+    @Published var totalDistance: Double = 0
+    @Published var currentSpeed: Double = 0
+    
+    var rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    private var cancellables = Set<AnyCancellable>()
     
     init(rideSession: RideSession) {
         self.rideSession = rideSession
+        setupSubscriptions()
+    }
+    
+    private func setupSubscriptions() {
+        // 주행 시간 구독
+        rideSession.$totalRideTime
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newTime in
+                self?.totalRideTime = newTime
+            }
+            .store(in: &cancellables)
+        
+        // 주행 거리 구독
+        rideSession.$totalDistance
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newDistance in
+                self?.totalDistance = newDistance
+            }
+            .store(in: &cancellables)
+        
+        // 현재 속도 구독
+        rideSession.$currentSpeed
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newSpeed in
+                self?.currentSpeed = newSpeed
+            }
+            .store(in: &cancellables)
     }
     
     func pauseRide() {
         rideEventSubject.send(.didPauseRide)
+        rideSession.pause()
+    }
+    
+    func formattedTotalRideTime() -> String {
+        let hours = Int(totalRideTime) / 3600
+        let minutes = Int(totalRideTime) / 60 % 60
+        let seconds = Int(totalRideTime) % 60
+        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+    
+    func formattedTotalDistance() -> String {
+        return String(format: "%.2f km", totalDistance)
+    }
+    
+    func formattedCurrentSpeed() -> String {
+        return String(format: "%.1f km/h", currentSpeed)
     }
     
 }

--- a/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
@@ -20,9 +20,11 @@ class PauseRideViewModel: ObservableObject, RideEventPublishable {
     
     func resumeRide(){
         rideEventSubject.send(.didResumeRide)
+        rideSession.resume()
     }
     
     func finishRide(){
         rideEventSubject.send(.didFinishRide)
+        rideSession.stop()
     }
 }

--- a/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
@@ -16,7 +16,8 @@ class RidePreparationViewModel: ObservableObject, RideEventPublishable {
     @Published var showLocationPermissionAlert = false
     /// 사용자 위치 권한 상태
     @Published var isLocationPermissionGranted = false
-    
+    /// 사용자 설정 속도 구간
+    @Published var userSettingTargetSpeedRange: ClosedRange<Double> = 5...15
     private let rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
@@ -35,6 +36,7 @@ class RidePreparationViewModel: ObservableObject, RideEventPublishable {
             return
         }
         rideEventSubject.send(.didStartRide)
+        rideSession.start(settedtargetSpeedRange: userSettingTargetSpeedRange)
     }
     
     /// 주행기록을 보여줍니다.


### PR DESCRIPTION
## 🔴 변경 사항 (What)
-`RideSession`에 타이머 프로퍼티 및 타이머 동작 메서드를 추가했습니다.  
-`RideSession`에 `currentSpeed`의 단위 변환 및 max 추가 
- `ActiveRideViewModel`에서 `RideSession` 프로퍼티 구독 및 발행  
- `ActiveView`에서 vm 로부터 발행된 프로퍼티 값 확인  
- ViewModel의 화면 이동로직 (send) 이후의 `RideSession`의 주행 관리 메서드 호출 추가 


## 🟠 변경 이유 (Why)
- 타이머를 통해 주행 시작 후 사용자 위치정보 변화가 없어도( 사용자가 멈춘 경우) 주행 시간 업데이트를 가능하도록 합니다. 
- m/s 를 km/h 단위로 변경하여 일반적인 속도계앱과 같은 단위를 제공합니다. 
- `RideSession`에서 관리되고 있는 주행 정보를 주행 중 화면에 표시합니다. 
- 화면이동으로 바뀐 화면에 대응하는 `RideSession`의 업데이트를 관리합니다. 


## 🟢 추가 노트 (Additional Notes)
-  현재 실내에서 GPS 드리프트 현상으로 이동하지 않아도 거리가 증가하는 현상이 있습니다. 향후 이것에 대한 최적화 작업이 필요합니다. 
