### PR TITLE
[enh] 속도 측정 기능 개선 

### DIFF
--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -108,6 +108,7 @@ class RideSession {
         guard state == .active else { return }
         state = .pause
         currentSpeed = 0
+        filteredSpeed = 0
         currentRestPeriod = RestPeriod(startTime: Date())
         LocationManager.shared.stopUpdatingLocation()
         stopTimer()
@@ -190,7 +191,7 @@ class RideSession {
         // 메인 스레드에서 UI 업데이트
         DispatchQueue.main.async {
             self.totalDistance = newTotalDistance
-            self.currentSpeed = max(newCurrentSpeed, 0)
+            self.currentSpeed = max(self.filteredSpeed, 0)
         }
         
         // 현재 위치를 이전 위치로 저장

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -37,6 +37,8 @@ class RideSession {
     private let filterFactor: Double = 0.3
     private var lastLocationUpdateTime: Date?
     private var speedCheckInterval: TimeInterval = 2.0
+    private var lastKnownSpeed: Double = 0.0
+    private let speedDecayFactor: Double = 0.9
     
     init() {
         setupLocationSubscription()
@@ -163,11 +165,13 @@ class RideSession {
         
         if let lastUpdate = lastLocationUpdateTime {
             let timeSinceLastUpdate = Date().timeIntervalSince(lastUpdate)
-            if timeSinceLastUpdate > speedCheckInterval && currentSpeed != 0 {
-                // speedCheckInterval 이상 위치 업데이트가 없으면 속도를 0으로 설정
+            if timeSinceLastUpdate > speedCheckInterval && currentSpeed > 0 {
+                // 속도를 점진적으로 감소시킵니다.
+                lastKnownSpeed *= pow(speedDecayFactor, timeSinceLastUpdate / speedCheckInterval)
+                
                 DispatchQueue.main.async {
-                    self.currentSpeed = 0
-                    self.filteredSpeed = 0
+                    self.currentSpeed = max(self.lastKnownSpeed, 0)
+                    self.filteredSpeed = self.currentSpeed
                 }
             }
         }
@@ -186,25 +190,29 @@ class RideSession {
             let distance = calculateDistance(from: previousLocation, to: locationData)
             newTotalDistance += distance
             
-            // locationData.speed가 유효하지 않은 경우 (-1.0), 계산된 속도 사용
-            if newCurrentSpeed < 0 {
-                let timeDifference = locationData.timestamp.timeIntervalSince(previousLocation.timestamp)
-                if timeDifference > 0 {
+            let timeDifference = locationData.timestamp.timeIntervalSince(previousLocation.timestamp)
+            if timeDifference > 0 {
+                // locationData.speed가 유효하지 않은 경우 계산된 속도를 사용합니다.
+                if newCurrentSpeed < 0 {
                     newCurrentSpeed = (distance / timeDifference) * 3600 // km/s -> km/h 변환
-                } else {
-                    newCurrentSpeed = 0
                 }
+                
+                // 저역 통과 필터 적용
+                filteredSpeed = (filterFactor * newCurrentSpeed) + ((1 - filterFactor) * filteredSpeed)
+                
+                // 속도 분포 업데이트 (필터링된 속도 사용)
+                speedDistribution.update(with: filteredSpeed, targetRange: targetSpeedRange, deltaTime: timeDifference)
+                
+                // lastKnownSpeed 업데이트
+                lastKnownSpeed = filteredSpeed
+            } else {
+                // 시간 차이가 0이거나 음수인 경우 이전 속도를 유지합니다.
+                newCurrentSpeed = lastKnownSpeed
             }
-            
-            // 저역 통과 필터 적용
-            filteredSpeed = (filterFactor * newCurrentSpeed) + ((1 - filterFactor) * filteredSpeed)
-            
-            // 속도 분포 업데이트 (필터링된 속도 사용)
-            let deltaTime = locationData.timestamp.timeIntervalSince(previousLocation.timestamp)
-            speedDistribution.update(with: filteredSpeed, targetRange: targetSpeedRange, deltaTime: deltaTime)
         } else {
             // 첫 위치 데이터의 경우, 필터링된 속도를 현재 속도로 초기화
             filteredSpeed = newCurrentSpeed
+            lastKnownSpeed = filteredSpeed
         }
         
         // 메인 스레드에서 UI 업데이트
@@ -215,7 +223,6 @@ class RideSession {
         
         // 현재 위치를 이전 위치로 저장
         previousLocation = locationData
-        
     }
 
     private func calculateDistance(from: LocationData, to: LocationData) -> Double {

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -186,7 +186,7 @@ class RideSession {
 
     private func calculateDistance(from: LocationData, to: LocationData) -> Double {
         let fromLocation = CLLocation(latitude: from.coordinate.latitude, longitude: from.coordinate.longitude)
-        let toLocation = CLLocation(latitude: to.coordinate.latitude, longitude: from.coordinate.longitude)
+        let toLocation = CLLocation(latitude: to.coordinate.latitude, longitude: to.coordinate.longitude)
         return toLocation.distance(from: fromLocation) / 1000 // km로 변환
     }
 

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -105,6 +105,7 @@ class RideSession {
     func pause() {
         guard state == .active else { return }
         state = .pause
+        currentSpeed = 0
         currentRestPeriod = RestPeriod(startTime: Date())
         LocationManager.shared.stopUpdatingLocation()
         stopTimer()

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -111,6 +111,7 @@ class RideSession {
         currentRestPeriod = RestPeriod(startTime: Date())
         LocationManager.shared.stopUpdatingLocation()
         stopTimer()
+        previousLocation = nil
     }
 
     /// 주행 재개

--- a/DomadoV/DomadoV/Service/LocationManager.swift
+++ b/DomadoV/DomadoV/Service/LocationManager.swift
@@ -27,7 +27,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     private override init() {
         super.init()
         locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
         authorizationPublisher.send(checkLocationAuthorization())
     }
     

--- a/DomadoV/DomadoV/Service/LocationManager.swift
+++ b/DomadoV/DomadoV/Service/LocationManager.swift
@@ -55,6 +55,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     /// 기기의 위치변경이 감지될때마다 새로운 위치를 subject를 통해 발행합니다. 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
+        guard location.horizontalAccuracy <= 12 else { return }
         locationSubject.send(location)
     }
     

--- a/DomadoV/DomadoV/Service/LocationManager.swift
+++ b/DomadoV/DomadoV/Service/LocationManager.swift
@@ -27,7 +27,10 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     private override init() {
         super.init()
         locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.distanceFilter = 2.0
+        locationManager.activityType = .fitness
+        locationManager.pausesLocationUpdatesAutomatically = true
         authorizationPublisher.send(checkLocationAuthorization())
     }
     


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `calculateDistance` 메서드에서 `toLocation` 변수 계산시 `from`경도를 사용하던 부분을 `to` 경도로 수정하였습니다.
- `pause` 메서드 호출시 `currentSpeed`를 0으로 업데이트 합니다. 
- `locationManager`에 사용자 위치 업데이트시 수평정확도를 통해 위치 데이터를 필터링합니다. 
- `handleNewLocation`에서 속도계산시 저역 통과 필터를 적용했습니다.
- `puase`시 `previousLocation` 값을 제거합니다.
- 현재속도를 필터링된 값을 사용합니다. 
- `LocationManager`에서 `CLLocationManager` 에 대한 설정을 변경했습니다. (distanceFilter, activityType, pausesLocationUpdatesAutomatically)
- 위치 업데이트가 없는 duration을 확인해서 속도를 업데이트하는 로직을 추가했습니다.
- 위치 업데이트가 없을 시에 하는 속도 업데이트가 점진적으로 이루어지도록 했습니다. 

## 🟠 변경 이유 (Why)
- 사용자의 현재 속도를 명확히 표시하고 급격한 속도변화를 줄여 사용자가 속도를 편하게 확인할 수 있도록 합니다. 
- `LocationManager`으로부터의 받은 위치 데이터 속도값을 바로 사용하지 않고 필터링하여 노이즈를 줄입니다. 
- `distanceFilter`를 적용해 일정 거리이상 움직이지 않으면 위치값을 발행하지 않도록 합니다. 
- 주행시간 업데이트시 사용하던 타이머를 사용, 마지막 속도 업데이트 시점을 체크하여 위치 데이터가 발행되지 않아도 속도를 업데이트할 수 있도록 합니다. (기존에 `handleNewLocation`에서 속도를 업데이트하여 위치데이터가 발행되지 않는 경우(사용자가 멈춘 경우) 속도가 업데이트 되지 않았습니다.)
- 위치 발행이 없을시 적용되는 속도 업데이트시 속도가 점진적으로 감소하도록 하여 부드러운 속도변화를 제공합니다. 

## 🟢 추가 노트 (Additional Notes)
- 실내 환경에서는 GPS 드래프트 현상으로 인해 움직이지 않아도 속도와 거리가 상승하는 현상이 있을 수 있습니다. 
- 실제환경에서 테스트 후 `LocationManager`의  `desiredAccuracy` 와 `distanceFilter` 값을 조절함으로써 속도 측정 로직을 더 개선할 수 있습니다. 
- 속도 업데이트 반응성을 개선하기 위해서는 저역통과 필터 계수를 조정할 수 있습니다. 
- 속도 측정 정확성 향상을 위해 필터링과 위치 데이터가 없을 경우에 대한 로직이 추가되면서 `RideSession`클래스가 무거워져 향후 속도 측정 정확성에 대한 기능은 따로 분리가 필요해보입니다. 
- 현재는 단순 저역 통과 필터가 적용되어 있으나 부드러운 속도 업데이트를 위해 이동평균필터를 추가할 수 있습니다. 
- GPS 노이즈를 줄이기 위해서 칼만필터를 사용이 가능해보이므로 해당 기술에 대한 조사 및 구현 가능성에 대해 알아보겠습니다. 