### PR TITLE
[enh] 정지시 속도 반영 개선 

### DIFF
--- a/DomadoV/DomadoV/Service/LocationManager.swift
+++ b/DomadoV/DomadoV/Service/LocationManager.swift
@@ -27,7 +27,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     private override init() {
         super.init()
         locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
         locationManager.distanceFilter = 2.0
         locationManager.activityType = .fitness
         locationManager.pausesLocationUpdatesAutomatically = true
@@ -58,7 +58,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     /// 기기의 위치변경이 감지될때마다 새로운 위치를 subject를 통해 발행합니다. 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
-        guard location.horizontalAccuracy <= 12 else { return }
+        guard location.horizontalAccuracy <= 20 else { return }
         locationSubject.send(location)
     }
     


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `speedCheckInterval` 1.8로 변경 
- 점진적 속도 감속 로직 삭제 
- `LocationManager` 위치 정확도 최고로 설정 
- `LocationManager` 수평 정확도 범위 넓힘 

## 🟠 변경 이유 (Why)
- 점진적 감속로직을 사용하니 정지시 정지 상태에 대한 화면 피드벡이 너무 느리게 반영되는 현상을 관찰했습니다. 
- 따라서 점진적 감속 로직을 제거하여 정지상태가 빠르게 화면에 반영될 수 있도록 하였습니다. 

## 🟢 추가 노트 (Additional Notes)
- 속도 갱신 flow
1. **조건**:`distanceFilter = 2 ` 이상의 위치 변화가 생김 & 해당 위치 변화의 수평정확도가 20 이내로 들어오는 경우, `LocationManager`로부터 현재 위치 발행 
2. 현재 위치가 발행시 `RideSession`에서 발행된 위치에 대하여 `handleNewLocation`을 통해 현재 속도 계산 및 화면에 반영 
3.  조건을 통과하지 않은 경우 (사용자가 `distanceFilter`이상 움직이지 않거나 현재 위치 신뢰성이 떨어지는 경우 )가 지정한 시간 `speedCheckInterval` 동안 이루어지면  움직임이 없는 것으로 판단`checkAndUpdateSpeed` 메서드가 실행되어 현재 속도를 0으로 만듭니다. 

- 조정시 고려사항 
1.  `speedCheckInterval`를 늘려 다음 위치데이터 발행을 더 기다리거나 아니면 줄여 정지 상태 판단을 빠르게 할 수 있습니다. 
2. `distanceFilter`를 짧게 만들어 위치 발행 주기를 더 짧게 만들 수 있습니다. 
3. 측정하려는 활동의 특성을 고려하여 위치 데이터 측정 요소들을 조정해야합니다. 
