### PR TITLE
[feat] CoreDataManager 구현

### DIFF
--- a/DomadoV/DomadoV/Persistent/CoreDataManager.swift
+++ b/DomadoV/DomadoV/Persistent/CoreDataManager.swift
@@ -5,9 +5,58 @@
 //  Created by 이종선 on 10/8/24.
 //
 
+import CoreData
 import Foundation
 
 /// dataModel을 사용해 데이터 구조를 설계하고 CoreData의 PersistentContainer와 Context 기본저장 로직을 관리합니다.
 class CoreDataManager {
     
+    static let shared = CoreDataManager()
+    
+    private init() {}
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "PacepalModel")
+        container.loadPersistentStores { _ , error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        return container
+    }()
+    
+    lazy var mainContext: NSManagedObjectContext = {
+        return persistentContainer.viewContext
+    }()
+    
+    func saveContext() {
+        saveContext(mainContext)
+    }
+    
+    func saveContext( _ context: NSManagedObjectContext) {
+        if context.parent == mainContext {
+            saveDerivedContext(context)
+            return
+        }
+        
+        context.perform {
+            do {
+                try context.save()
+            } catch let error as NSError {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+    }
+    
+    func saveDerivedContext(_ context: NSManagedObjectContext) {
+        context.perform { [self] in
+            do {
+                try context.save()
+            } catch let error as NSError {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+            
+            saveContext(mainContext)
+        }
+    }
 }


### PR DESCRIPTION
# CoreDataManager 구현 및 사용 가이드

## 🔴 변경 사항 (What)
- CoreDataManager 싱글톤 클래스 구현
- NSPersistentContainer를 사용한 Core Data 스택 초기화
- 메인 컨텍스트 및 파생 컨텍스트 저장 로직 구현
- 컨텍스트 계층 구조를 고려한 저장 메커니즘 구현

## 🟠 변경 이유 (Why)
- 앱 전체에서 일관된 Core Data 스택 사용을 위해
- 데이터 관리 로직의 중앙화로 코드 중복 감소
- 멀티 스레딩 환경에서의 안전한 데이터 조작을 위해
- UI 반응성 향상 및 백그라운드 작업 지원

## 🟢 추가 노트 (Additional Notes)
`NSPersistentContainer(name: "PacepalModel")`에서 사용하고 있는 PacepalModel에 대한 dataModel을 만들어야합니다. 



