### PR TITLE
[feat] 주행 요약 기능 구현 

### DIFF
--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -25,7 +25,7 @@ class RideSession {
     private(set) var restPeriods: [RestPeriod] = []
     private(set) var totalRestTime: TimeInterval = 0
     private var averageSpeed: Double {
-        let effectiveRideTime = totalRideTime > 0 ? totalRideTime : 1  
+        let effectiveRideTime = totalRideTime > 0 ? totalRideTime : 1
         return totalDistance / (effectiveRideTime / 3600)
     }
     

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -24,7 +24,10 @@ class RideSession {
     private(set) var locations: [LocationData] = []
     private(set) var restPeriods: [RestPeriod] = []
     private(set) var totalRestTime: TimeInterval = 0
-    private(set) var averageSpeed: Double = 0
+    private var averageSpeed: Double {
+        let effectiveRideTime = totalRideTime > 0 ? totalRideTime : 1  
+        return totalDistance / (effectiveRideTime / 3600)
+    }
     
     private var currentRestPeriod: RestPeriod?
     private var targetSpeedRange: ClosedRange<Double> = 0...15
@@ -221,7 +224,13 @@ class RideSession {
     }
 
     /// 주행종료후 주행 요약 생성
-    func generateRideSummary(){
-      
+    func generateRideSummary() -> RideSummary {
+        return RideSummary(
+            totalDistance: totalDistance,
+            totalRideTime: totalRideTime,
+            totalRestTime: totalRestTime,
+            averageSpeed: averageSpeed,
+            speedDistribution: speedDistribution
+        )
     }
 }

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -15,22 +15,156 @@ import SwiftUI
 /// 4. 속도 구간별 시간을 보여줍니다.
 /// 5. 닫기 버튼을 눌러 주행준비 화면으로 돌아갑니다.
 struct RideSummaryView: View {
-    
     @ObservedObject var vm: RideSummaryViewModel
     
+    private let speedLabels = ["목표 속도 미만", "목표 속도 내", "목표 속도 초과"]
+    private let speedColors: [Color] = [.blue, .green, .red]
+    private let barSpacing: CGFloat = 4
+    
     var body: some View {
-       
-        VStack(spacing: 20){
+        VStack(spacing: 20) {
+            Text("주행 요약")
+                .font(.largeTitle)
             
-            Button {
-                vm.dismissSummary()
-            } label: {
-                Text("주행 준비 화면으로 돌아가기")
+            if let summary = vm.rideSummary {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("총 거리: \(summary.totalDistance, specifier: "%.2f") km")
+                    Text("총 시간: \(vm.formatTime(summary.totalTime))")
+                    
+                    
+                    Text("총 주행시간: \(vm.formatTime(summary.totalRideTime)) ")
+                    Text("총 휴식 시간: \(vm.formatTime(summary.totalRestTime))")
+                    
+                    
+                    Text("평균 속도: \(summary.averageSpeed, specifier: "%.1f") km/h")
+                    
+                }
+                
+                Text("속도 구간별 주행 시간")
+                    .font(.headline)
+                    .padding(.top)
+                
+                let segments = vm.calculateSpeedDistribution()
+                
+                GeometryReader { geometry in
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(spacing: barSpacing) {
+                            ForEach(0..<segments.count, id: \.self) { index in
+                                VStack(spacing: 4) {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(speedColors[index])
+                                        .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio, height: 30)
+                                    
+                                    Text(vm.formatTime(segments[index].time))
+                                        .font(.caption)
+                                        .foregroundColor(.black)
+                                }
+                            }
+                        }
+                        
+                        HStack(spacing: 0) {
+                            ForEach(0..<segments.count, id: \.self) { index in
+                                Text(speedLabels[index])
+                                    .font(.caption)
+                                    .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio)
+                                    .multilineTextAlignment(.center)
+                                
+                                if index < segments.count - 1 {
+                                    Spacer().frame(width: barSpacing)
+                                }
+                            }
+                        }
+                        .padding(.top, 4)
+                    }
+                }
+                .frame(height: 80)
+                .padding(.vertical)
+                
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(0..<segments.count, id: \.self) { index in
+                        HStack {
+                            Circle()
+                                .fill(speedColors[index])
+                                .frame(width: 10, height: 10)
+                            Text("\(speedLabels[index]): \(vm.formatTime(segments[index].time)) (\(Int(segments[index].ratio * 100))%)")
+                        }
+                    }
+                }
+                .padding(.top)
+            } else {
+                Text("주행 요약 정보를 불러오는 중...")
             }
+            
+            Button("완료") {
+                vm.dismissSummary()
+            }
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
+            .padding(.top)
+        }
+        .padding()
+        .onAppear {
+            vm.getSummary()
         }
     }
 }
 
-#Preview {
-    RideSummaryView(vm: RideSummaryViewModel(rideSession: RideSession()))
+struct RideSummaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            RideSummaryView(vm: RideSummaryViewModel(rideSession: MockRideSession(scenario: .normal)))
+                .previewDisplayName("Normal Ride")
+            
+            RideSummaryView(vm: RideSummaryViewModel(rideSession: MockRideSession(scenario: .mostlyBelowTarget)))
+                .previewDisplayName("Mostly Below Target")
+            
+            RideSummaryView(vm: RideSummaryViewModel(rideSession: MockRideSession(scenario: .mostlyAboveTarget)))
+                .previewDisplayName("Mostly Above Target")
+        }
+    }
+}
+
+// MARK: - Mock Data for Previews
+
+enum RideScenario {
+    case normal, mostlyBelowTarget, mostlyAboveTarget
+}
+
+class MockRideSession: RideSession {
+    let scenario: RideScenario
+    
+    init(scenario: RideScenario) {
+        self.scenario = scenario
+    }
+    
+    override func generateRideSummary() -> RideSummary {
+        switch scenario {
+        case .normal:
+            return RideSummary(
+                totalDistance: 30.5,
+                totalRideTime: 5400,  // 1.5 hours
+                totalRestTime: 600,   // 10 minutes
+                averageSpeed: 20.3,
+                speedDistribution: SpeedDistribution(belowTarget: 1800, withinTarget: 2700, aboveTarget: 900)
+            )
+        case .mostlyBelowTarget:
+            return RideSummary(
+                totalDistance: 25.0,
+                totalRideTime: 7200,  // 2 hours
+                totalRestTime: 900,   // 15 minutes
+                averageSpeed: 15.0,
+                speedDistribution: SpeedDistribution(belowTarget: 5400, withinTarget: 1440, aboveTarget: 360)
+            )
+        case .mostlyAboveTarget:
+            return RideSummary(
+                totalDistance: 40.0,
+                totalRideTime: 3600,  // 1 hour
+                totalRestTime: 300,   // 5 minutes
+                averageSpeed: 30.0,
+                speedDistribution: SpeedDistribution(belowTarget: 360, withinTarget: 1080, aboveTarget: 2160)
+            )
+        }
+    }
 }

--- a/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
@@ -6,9 +6,12 @@
 //
 
 import Combine
+import Foundation
 
 /// 주행종료화면에 대한 정보와 동작을 관리합니다.
 class RideSummaryViewModel: ObservableObject, RideEventPublishable {
+    
+    @Published private(set) var rideSummary: RideSummary?
     
     let rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
@@ -21,5 +24,40 @@ class RideSummaryViewModel: ObservableObject, RideEventPublishable {
     /// 준비화면으로 돌아가기 
     func dismissSummary() {
         rideEventSubject.send(.didReturnToPreparation)
+    }
+    
+    /// RideSession으로부터 주행 요약 정보 가져오기
+    func getSummary() {
+        rideSummary = rideSession.generateRideSummary()
+     }
+    
+    func calculateSpeedDistribution() -> [(ratio: Double, time: TimeInterval)] {
+        guard let summary = rideSummary, summary.totalTime > 0 else {
+            return []
+        }
+        
+        let distribution = summary.speedDistribution
+        let totalTargetTime = distribution.belowTarget + distribution.withinTarget + distribution.aboveTarget
+        
+        guard totalTargetTime > 0 else {
+            return []
+        }
+        
+        let belowRatio = distribution.belowTarget / totalTargetTime
+        let withinRatio = distribution.withinTarget / totalTargetTime
+        let aboveRatio = distribution.aboveTarget / totalTargetTime
+        
+        return [
+            (belowRatio, summary.totalTime * belowRatio),
+            (withinRatio, summary.totalTime * withinRatio),
+            (aboveRatio, summary.totalTime * aboveRatio)
+        ]
+    }
+    
+    func formatTime(_ seconds: TimeInterval) -> String {
+        let hours = Int(seconds) / 3600
+        let minutes = (Int(seconds) % 3600) / 60
+        let remainingSeconds = Int(seconds) % 60
+        return String(format: "%02d:%02d:%02d", hours, minutes, remainingSeconds)
     }
 }


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `RideSession`의 평균속도를 연산 프로퍼티로 변경하였습니다. 
- `RideSession`이 관리하는 주행정보들을 `RideSummary` 인스턴스로 반환하는 `generateRideSummary` 메서드를 구현하였습니다.
- `RideSummaryViewModel`에 `RideSession`의 `generateRideSummary` 호출하여 `RideSummary`를 얻어 이를 화면에 보여줍니다. 
- 속도 구간별 시간의 경우, `RideSummary.speedDistribution`의 각 속도 구간별 시간의 비율대로 전체 주행 시간을 나누어 반환하도로 하였습니다. 
- `RideSummaryView`  등장시 `vm.getSummary` 메서드를 호출하여 RideSession으로부터 `RideSummaryViewModel`로 주행정보를 가져옵니다. 
- `RideSummaryView`는 `RideSummary`를 통해 필요한 정보를 화면에 표시합니다. 

## 🟠 변경 이유 (Why)
종료된 주행에 대한 사용자에게 보여줍니다. 

## 🟢 추가 노트 (Additional Notes)
- 현재 뷰는 필요한 정보만 표시되고 디자인이 반영되지 않은 상태입니다. 
- 거리나 시간 단위를 포멧팅하는 별도의 Extension 이 필요해보입니다. 
