### PR TITLE
[feat] RideHistoryViewModel 주행기록 fetch 로직 추가 

### DIFF
--- a/DomadoV/DomadoV/Model/RideRecord.swift
+++ b/DomadoV/DomadoV/Model/RideRecord.swift
@@ -1,0 +1,59 @@
+//
+//  RideRecord.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/17/24.
+//
+
+import Foundation
+import CoreLocation
+
+struct RideRecord: Identifiable {
+    let id: String
+    let startTime: Date
+    let endTime: Date
+    let totalDistance: Double
+    let totalRidingTime: Double
+    let targetSpeedLower: Double
+    let targetSpeedUpper: Double
+    let timeInSlowZone: Double
+    let timeInTargetZone: Double
+    let timeInFastZone: Double
+    let route: [CLLocationCoordinate2D]
+    
+    var averageSpeed: Double {
+        return totalDistance / (totalRidingTime / 3600) // km/h
+    }
+    
+    var totalDuration: TimeInterval {
+        return endTime.timeIntervalSince(startTime)
+    }
+    
+    var totalRestTime: TimeInterval {
+        return totalDuration - totalRidingTime
+    }
+    
+    init(id: String = UUID().uuidString,
+         startTime: Date,
+         endTime: Date,
+         totalDistance: Double,
+         totalRidingTime: Double,
+         targetSpeedLower: Double,
+         targetSpeedUpper: Double,
+         timeInSlowZone: Double,
+         timeInTargetZone: Double,
+         timeInFastZone: Double,
+         route: [CLLocationCoordinate2D]) {
+        self.id = id
+        self.startTime = startTime
+        self.endTime = endTime
+        self.totalDistance = totalDistance
+        self.totalRidingTime = totalRidingTime
+        self.targetSpeedLower = targetSpeedLower
+        self.targetSpeedUpper = targetSpeedUpper
+        self.timeInSlowZone = timeInSlowZone
+        self.timeInTargetZone = timeInTargetZone
+        self.timeInFastZone = timeInFastZone
+        self.route = route
+    }
+}

--- a/DomadoV/DomadoV/Service/RideHistoryManager.swift
+++ b/DomadoV/DomadoV/Service/RideHistoryManager.swift
@@ -58,12 +58,27 @@ class RideHistoryManager {
         }
     }
     
-    func fetchAllRides() -> [Ride] {
+    func fetchAllRides() -> [RideRecord] {
         let context = coreDataManager.mainContext
         let fetchRequest: NSFetchRequest<Ride> = Ride.fetchRequest()
         
         do {
-            return try context.fetch(fetchRequest)
+            let rides = try context.fetch(fetchRequest)
+            return rides.map { ride in
+                RideRecord(
+                    id: ride.id ?? UUID().uuidString,
+                    startTime: ride.startTime ?? Date(),
+                    endTime: ride.endTime ?? Date(),
+                    totalDistance: ride.totalDistance,
+                    totalRidingTime: ride.totalRidingTime,
+                    targetSpeedLower: ride.targetSpeedLower,
+                    targetSpeedUpper: ride.targetSpeedUpper,
+                    timeInSlowZone: ride.timeInSlowZone,
+                    timeInTargetZone: ride.timeInTargetZone,
+                    timeInFastZone: ride.timeInFastZone,
+                    route: ride.route ?? []
+                )
+            }
         } catch {
             print("Error fetching rides: \(error)")
             return []

--- a/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
@@ -9,8 +9,16 @@ import Combine
 
 class RideHistoryViewModel: ObservableObject, RideEventPublishable {
     
+    @Published var records: [RideRecord] = []
+    
+    private let rideHistoryManager: RideHistoryManager
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    
+    init(rideHistoryManager: RideHistoryManager = .shared) {
+        self.rideHistoryManager = rideHistoryManager
+        records = rideHistoryManager.fetchAllRides()
+    }
     
     /// 주행준비화면으로 돌아가기
     func returnToPreparation() {


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `RideRecord` DTO 추가
- `RideHistoryManager`의 fetch 메서드 `RideRecord` 반환 
- `RideHistoryViewModel` 의 `RideRecord` 모델 주행기록 관리 

## 🟠 변경 이유 (Why)
- 엔티티를 `RideRecord`로 변환하여 비즈니스 계층에 노출하지 않습니다. 
- `RideHistoryViewModel` 에서  코어데이터로부터 저장된 주행기록을 가져옵니다. 