### PR TITLE
[fix] 롱프레스를 통한 주행 정지

### DIFF
--- a/DomadoV/DomadoV/View/PauseRideView.swift
+++ b/DomadoV/DomadoV/View/PauseRideView.swift
@@ -19,6 +19,7 @@ struct PauseRideView: View {
     @ObservedObject var vm: PauseRideViewModel
     
     @State private var showAlert = false
+    @State private var isLongPressing = false
     
     var body: some View {
             ZStack {
@@ -96,29 +97,41 @@ struct PauseRideView: View {
     }
     
     private var stopButton: some View {
-        Button(action: { showAlert = true
+        Button(action: {
+            // 탭 동작
+            print("Tapped")
+            showAlert = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            showAlert = false
-                        }
+                showAlert = false
+            }
         }) {
             Image(systemName: "stop.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 40, height: 40)
-                .foregroundColor(.gray)
+                .foregroundColor(isLongPressing ? .white : .gray)
                 .frame(width: 104, height: 104)
-                .background(Color.white)
+                .background(isLongPressing ? Color.gray : Color.white)
                 .clipShape(Circle())
                 .overlay(Circle().stroke(Color.gray, lineWidth: 2))
+                .scaleEffect(isLongPressing ? 0.9 : 1.0)
         }
-        .gesture(
+        .simultaneousGesture(
             LongPressGesture(minimumDuration: 1.0)
+                .onChanged { isPressing in
+                    isLongPressing = isPressing
+                    if isPressing {
+                        print("Long press started")
+                    }
+                }
                 .onEnded { _ in
+                    print("Long press completed")
                     vm.finishRide()
+                    isLongPressing = false
                 }
         )
+        .animation(.easeInOut(duration: 0.2), value: isLongPressing)
     }
-    
     private var playButton: some View {
         Button{
             vm.resumeRide()
@@ -139,42 +152,45 @@ struct PauseRideView: View {
     
     private var alertView: some View {
         VStack(alignment: .center) {
-            Spacer()
             alertContent
-            .overlay(alignment: .topTrailing) {
-            closeButton
-                        }
-            .frame(width: 333, height: 88)
-            .background(Color.white)
-            .cornerRadius(10)
-            .shadow(radius: 5)
+                .frame(width: 333, height: 88)
+                .background(Color.white)
+                .cornerRadius(10)
+                .shadow(radius: 5)
             Spacer().frame(height: 530)
+        }
+        .overlay(alignment: .topTrailing) {
+            closeButton
         }
     }
     
     private var alertContent: some View {
         HStack(alignment: .center) {
             Image(systemName: "exclamationmark.bubble")
-                .foregroundColor(.midnightCharcoal)
+                .foregroundColor(.gray)
                 .opacity(0.5)
             Text("길게 눌러서 주행을 종료하세요.")
                 .customFont(.infoTitle)
-                .foregroundColor(.midnightCharcoal)
+                .foregroundColor(.gray)
         }
         .frame(maxWidth: .infinity)
     }
     
     private var closeButton: some View {
-        Button(action: { showAlert = false }) {
+        Button(action: {
+            print("버튼이 닫혔습니다")
+            showAlert = false
+        }) {
             Image(systemName: "xmark")
-                .foregroundColor(.midnightCharcoal)
+                .foregroundColor(.gray)
                 .opacity(0.3)
-                .padding(.vertical, -20)
-                .padding(.horizontal, 10)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
         }
+      
     }
 }
-
+    
 #Preview {
     PauseRideView(vm: PauseRideViewModel(rideSession: RideSession()))
 }


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- alert의 색상을 gray로 변경하였습니다. 
- alert을 구성하는 Content를 x 버튼 터치 영역을 확장했습니다. 
- `isLongPressing ` 프로퍼티를 추가했습니다. 
- `simultaneousGesture` 와 `LongPressGesture `를 이용해 짧은 탭과 긴 탭을 구분합니다. 

## 🟠 변경 이유 (Why)
- 짧은 탭에 대해서는 알림이 긴 탭에 대해서는 주행 정지가 가능하도록 변경합니다. 