### PR TITLE
[bug] 경로 데이터 없을시 저장 실패 

### DIFF
--- a/DomadoV/DomadoV/Persistent/PacepalModel.xcdatamodeld/PacepalModel.xcdatamodel/contents
+++ b/DomadoV/DomadoV/Persistent/PacepalModel.xcdatamodeld/PacepalModel.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="Ride" representedClassName="Ride" syncable="YES">
         <attribute name="endTime" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="String"/>
-        <attribute name="routeData" attributeType="Binary"/>
+        <attribute name="routeData" optional="YES" attributeType="Binary"/>
         <attribute name="startTime" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="targetSpeedLower" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="targetSpeedUpper" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- 주행 기록 엔티티의 routeData 속성을 옵셔널로 변경했습니다. 

## 🟠 변경 이유 (Why)
- 주행기록이 존재하지 않아도 주행기록에 대한 저장이 일단 가능하게 합니다. 

## 🟢 추가 노트 (Additional Notes)
- 주행 경로 속성을 사용시 해당 옵셔널 언래핑하는 과정이 요구됩니다. 
