### PR TITLE
[enh] 주행 정지시 주행 기록 저장

### DIFF
--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -41,7 +41,10 @@ class RideSession {
     private var lastLocationUpdateTime: Date?
     private var speedCheckInterval: TimeInterval = 1.8
     
-    init() {
+    let rideHistoryManager: RideHistoryManager
+    
+    init(rideHistoryManager: RideHistoryManager = .shared) {
+        self.rideHistoryManager = rideHistoryManager
         setupLocationSubscription()
         setupAuthorizationSubscription()
     }
@@ -141,6 +144,7 @@ class RideSession {
         state = .summary
         LocationManager.shared.stopUpdatingLocation()
         stopTimer()
+        rideHistoryManager.saveRide(from: self)
     }
     
     private func startTimer() {

--- a/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
@@ -14,19 +14,16 @@ class RideSummaryViewModel: ObservableObject, RideEventPublishable {
     @Published private(set) var rideSummary: RideSummary?
     
     let rideSession: RideSession
-    let rideHistoryManager: RideHistoryManager
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
     
-    init(rideSession: RideSession, rideHistoryManager: RideHistoryManager = .shared) {
+    init(rideSession: RideSession) {
         self.rideSession = rideSession
-        self.rideHistoryManager = rideHistoryManager
     }
     
     /// 준비화면으로 돌아가기 
     func dismissSummary() {
         rideEventSubject.send(.didReturnToPreparation)
-        rideHistoryManager.saveRide(from: rideSession)
     }
     
     /// RideSession으로부터 주행 요약 정보 가져오기


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `RideSummaryViewModel `에서 주행 기록과 관련되어 있는 `RideHistoryManager `와 `saveRide`를 제거했습니다. 
- `RideSession`에 `RideHistoryManager` 프로퍼티를 추가했습니다. 
- `RideSession`의 stop메서드에서`rideHistoryManager.saveRide(from: self)`를 호출합니다. 

## 🟠 변경 이유 (Why)
-  해당 변경으로 주행이 종료된 경우 바로 해당 주행에 대한 기록을 저장합니다. 
- 이를 통해 사용자가 주행요약 화면에서 앱을 종료하였을 때 주행기록이 저장되지 않는 경우를 예방할 수 있습니다. 
