### PR TITLE
[feat] 지도상 주행 경로를 표시합니다. 

### DIFF
--- a/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
+++ b/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
@@ -1,0 +1,117 @@
+//
+//  RideRouteMapView.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/19/24.
+//
+
+import SwiftUI
+import MapKit
+
+
+struct RideRouteMapView: View {
+    let route: [CLLocationCoordinate2D]
+    @State private var position: MapCameraPosition
+    
+    init(route: [CLLocationCoordinate2D]) {
+        self.route = route
+        
+        // 초기 위치 설정
+        if let firstCoordinate = route.first {
+            _position = State(initialValue: .region(MKCoordinateRegion(
+                center: firstCoordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+            )))
+        } else {
+            // 기본 위치 설정 (예: 서울)
+            _position = State(initialValue: .region(MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780),
+                span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+            )))
+        }
+    }
+    
+    var body: some View {
+        if route.isEmpty {
+            Text("경로 없음")
+                .font(.title)
+                .foregroundColor(.secondary)
+                .frame(height: 300)
+        } else {
+            Map(position: $position) {
+                MapPolyline(coordinates: route)
+                    .stroke(
+                        .lavenderPurple,
+                        style: StrokeStyle(
+                            lineWidth: 8,
+                            lineCap: .round,
+                            lineJoin: .round
+                        )
+                    )
+                    
+            }
+            .frame(height: 300)
+            .onAppear {
+                setRegionToFitRoute()
+            }
+        }
+    }
+    
+    private func setRegionToFitRoute() {
+        guard !route.isEmpty else { return }
+        
+        var minLat = route[0].latitude
+        var maxLat = route[0].latitude
+        var minLon = route[0].longitude
+        var maxLon = route[0].longitude
+        
+        for coordinate in route {
+            minLat = min(minLat, coordinate.latitude)
+            maxLat = max(maxLat, coordinate.latitude)
+            minLon = min(minLon, coordinate.longitude)
+            maxLon = max(maxLon, coordinate.longitude)
+        }
+        
+        let center = CLLocationCoordinate2D(
+            latitude: (minLat + maxLat) / 2,
+            longitude: (minLon + maxLon) / 2
+        )
+        
+        let span = MKCoordinateSpan(
+            latitudeDelta: (maxLat - minLat) * 1.1,
+            longitudeDelta: (maxLon - minLon) * 1.1
+        )
+        
+        position = .region(MKCoordinateRegion(center: center, span: span))
+    }
+}
+
+struct RideRouteMapView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            // 경로가 있는 경우
+            RideRouteMapView(route: [
+                CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780),
+                CLLocationCoordinate2D(latitude: 37.5668, longitude: 126.9782),
+                CLLocationCoordinate2D(latitude: 37.5670, longitude: 126.9785),
+                CLLocationCoordinate2D(latitude: 37.5672, longitude: 126.9788),
+                CLLocationCoordinate2D(latitude: 37.5675, longitude: 126.9790),
+                CLLocationCoordinate2D(latitude: 37.5678, longitude: 126.9793),
+                CLLocationCoordinate2D(latitude: 37.5680, longitude: 126.9795),
+                CLLocationCoordinate2D(latitude: 37.5683, longitude: 126.9798),
+                CLLocationCoordinate2D(latitude: 37.5685, longitude: 126.9800),
+                CLLocationCoordinate2D(latitude: 37.5688, longitude: 126.9803),
+                CLLocationCoordinate2D(latitude: 37.5690, longitude: 126.9805),
+                CLLocationCoordinate2D(latitude: 37.5693, longitude: 126.9808),
+                CLLocationCoordinate2D(latitude: 37.5695, longitude: 126.9810),
+                CLLocationCoordinate2D(latitude: 37.5698, longitude: 126.9813),
+                CLLocationCoordinate2D(latitude: 37.5700, longitude: 126.9815)
+            ])
+            .previewDisplayName("With Route")
+
+            // 경로가 없는 경우
+            RideRouteMapView(route: [])
+            .previewDisplayName("Without Route")
+        }
+    }
+}


### PR DESCRIPTION
## 🔴 변경 사항 (What)
1. `RideRouteMapView` 구조체 구현:
   - 주어진 경로를 지도에 표시하는 SwiftUI 뷰 생성
   - 경로가 비어있을 때와 있을 때의 다른 뷰 표시 로직 구현
2. 지도 초기화 및 경로 표시:
   - `MapKit`을 사용하여 지도 뷰 구현
   - 주어진 좌표 배열을 기반으로 경로를 `MapPolyline`으로 표시
3. 동적 지도 영역 설정:
   - 경로의 모든 좌표를 포함하는 최적의 지도 영역을 계산하는 로직 구현
4. 프리뷰 제공:
   - 경로가 있는 경우와 없는 경우에 대한 프리뷰 구현

## 🟠 변경 이유 (Why)
1. 사용자 경험 향상:
   - 라이드 루트를 시각적으로 표시하여 사용자가 경로를 쉽게 이해할 수 있도록 함
2. 동적 데이터 처리:
   - 다양한 경로 데이터에 대응할 수 있는 유연한 뷰 구현
3. 성능 최적화:
   - 경로에 따라 자동으로 지도 영역을 조정하여 사용자가 수동으로 조작할 필요 없이 전체 경로를 한눈에 볼 수 있도록 함

## 🟢 추가 노트 (Additional Notes)
1. 코드 구조 설명:
   - `RideRouteMapView` 구조체는 `route` 파라미터를 받아 초기화됩니다. 이 파라미터는 `CLLocationCoordinate2D` 배열로, 라이드 경로의 좌표들을 나타냅니다.
   - `init` 메서드에서는 초기 지도 위치를 설정합니다. 경로가 있으면 첫 번째 좌표를 중심으로, 없으면 서울의 좌표를 기본값으로 사용합니다.
   - `body` 프로퍼티에서는 경로의 유무에 따라 다른 뷰를 표시합니다. 경로가 없으면 "경로 없음" 텍스트를, 있으면 지도와 경로를 표시합니다.
   - `setRegionToFitRoute()` 메서드는 모든 경로 좌표를 포함하는 최적의 지도 영역을 계산합니다.

2. 사용된 주요 SwiftUI 및 MapKit 기능:
   - `Map` 뷰를 사용하여 지도를 표시합니다.
   - `MapPolyline`을 사용하여 경로를 그립니다.
   - `MapCameraPosition`을 사용하여 지도의 위치와 줌 레벨을 제어합니다.

3. 커스텀 스타일링:
   - 경로선의 색상을 `.lavenderPurple`로 설정하고, 선의 두께와 모서리 스타일을 지정하여 시각적으로 보기 좋게 만들었습니다.

4. 프리뷰 구현:
   - 개발 과정에서 빠른 피드백을 위해 경로가 있는 경우와 없는 경우에 대한 프리뷰를 제공합니다.

5. 향후 개선 사항:
   - 경로의 시작점과 종료점을 특별히 표시하는 기능을 추가할 수 있습니다.

