### PR TITLE
[feat] 실제 저장된 주행기록 보여주기 

### DIFF
--- a/DomadoV/DomadoV/Extension/Extension+Date.swift
+++ b/DomadoV/DomadoV/Extension/Extension+Date.swift
@@ -1,0 +1,51 @@
+//
+//  Extension+Date.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/19/24.
+//
+
+import Foundation
+
+enum DateFormatOption {
+    case dateOnly
+    case dayOfWeekOnly
+    case dateAndDayOfWeek
+}
+
+enum TimeFormatOption {
+    case hourMinute
+    case hourMinuteSecond
+}
+
+extension Date {
+    func formatAsKoreanDate(option: DateFormatOption = .dateAndDayOfWeek) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        
+        switch option {
+        case .dateOnly:
+            dateFormatter.dateFormat = "yyyy년 MM월 dd일"
+        case .dayOfWeekOnly:
+            dateFormatter.dateFormat = "EEEE"
+        case .dateAndDayOfWeek:
+            dateFormatter.dateFormat = "yyyy년 MM월 dd일 EEEE"
+        }
+        
+        return dateFormatter.string(from: self)
+    }
+    
+    func formatAsKoreanTime(option: TimeFormatOption = .hourMinute) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        
+        switch option {
+        case .hourMinute:
+            dateFormatter.dateFormat = "HH시 mm분"
+        case .hourMinuteSecond:
+            dateFormatter.dateFormat = "HH시 mm분 ss초"
+        }
+        
+        return dateFormatter.string(from: self)
+    }
+}

--- a/DomadoV/DomadoV/Extension/Extension+Double.swift
+++ b/DomadoV/DomadoV/Extension/Extension+Double.swift
@@ -1,0 +1,18 @@
+//
+//  Extension+Double.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/19/24.
+//
+import Foundation
+
+extension Double {
+    func formatToDecimal(_ fractionDigits: Int) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.minimumFractionDigits = fractionDigits
+        numberFormatter.maximumFractionDigits = fractionDigits
+        
+        return numberFormatter.string(from: NSNumber(value: self)) ?? "\(self)"
+    }
+}

--- a/DomadoV/DomadoV/Extension/Extension+TimeInterval.swift
+++ b/DomadoV/DomadoV/Extension/Extension+TimeInterval.swift
@@ -1,0 +1,24 @@
+//
+//  extension+TimeInterval.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/19/24.
+//
+
+import Foundation
+
+/// 초단위 시간을 받아 시간 : 분 : 초 형태로 변환합니다. 
+extension TimeInterval {
+    func formatTime() -> String {
+        let totalSeconds = Int(self)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let remainingSeconds = totalSeconds % 60
+        
+        let hoursString = String(format: "%02d", hours)
+        let minutesString = String(format: "%02d", minutes)
+        let secondsString = String(format: "%02d", remainingSeconds)
+        
+        return "\(hoursString):\(minutesString):\(secondsString)"
+    }
+}

--- a/DomadoV/DomadoV/Extension/Extension+TimeInterval.swift
+++ b/DomadoV/DomadoV/Extension/Extension+TimeInterval.swift
@@ -21,4 +21,15 @@ extension TimeInterval {
         
         return "\(hoursString):\(minutesString):\(secondsString)"
     }
+    
+    func formatTimeInMinutes() -> String {
+        let hours = Int(self) / 3600
+        let minutes = (Int(self) % 3600) / 60
+        
+        if hours > 0 {
+            return String(format: "%d시간 %02d분", hours, minutes)
+        } else {
+            return String(format: "%d분", minutes)
+        }
+    }
 }

--- a/DomadoV/DomadoV/Model/RideRecord.swift
+++ b/DomadoV/DomadoV/Model/RideRecord.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreLocation
 
-struct RideRecord: Identifiable {
+struct RideRecord: Identifiable, Hashable{
     let id: String
     let startTime: Date
     let endTime: Date
@@ -22,7 +22,8 @@ struct RideRecord: Identifiable {
     let route: [CLLocationCoordinate2D]
     
     var averageSpeed: Double {
-        return totalDistance / (totalRidingTime / 3600) // km/h
+        guard totalRidingTime > 0 else { return 0 }
+        return totalDistance / (Double(totalRidingTime) / 3600.0) // km/h
     }
     
     var totalDuration: TimeInterval {
@@ -55,5 +56,13 @@ struct RideRecord: Identifiable {
         self.timeInTargetZone = timeInTargetZone
         self.timeInFastZone = timeInFastZone
         self.route = route
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
+    static func == (lhs: RideRecord, rhs: RideRecord) -> Bool {
+        return lhs.id == rhs.id
     }
 }

--- a/DomadoV/DomadoV/Model/SpeedDistribution.swift
+++ b/DomadoV/DomadoV/Model/SpeedDistribution.swift
@@ -23,3 +23,30 @@ struct SpeedDistribution {
         }
     }
 }
+
+extension SpeedDistribution {
+
+    static func calculateSpeedDistribution(speedDistribution: SpeedDistribution, totalTime: TimeInterval) -> [(ratio: Double, time: TimeInterval)] {
+        guard totalTime > 0 else {
+            return []
+        }
+        
+        let distribution = speedDistribution
+        let totalTargetTime = distribution.belowTarget + distribution.withinTarget + distribution.aboveTarget
+        
+        guard totalTargetTime > 0 else {
+            return []
+        }
+        
+        let belowRatio = distribution.belowTarget / totalTargetTime
+        let withinRatio = distribution.withinTarget / totalTargetTime
+        let aboveRatio = distribution.aboveTarget / totalTargetTime
+        
+        // (주행구간 비율, 해당구간 시간 )
+        return [
+            (belowRatio, totalTime * belowRatio),
+            (withinRatio, totalTime * withinRatio),
+            (aboveRatio, totalTime * aboveRatio)
+        ]
+    }
+}

--- a/DomadoV/DomadoV/Service/RideHistoryManager.swift
+++ b/DomadoV/DomadoV/Service/RideHistoryManager.swift
@@ -61,7 +61,8 @@ class RideHistoryManager {
     func fetchAllRides() -> [RideRecord] {
         let context = coreDataManager.mainContext
         let fetchRequest: NSFetchRequest<Ride> = Ride.fetchRequest()
-        
+        let sortDescriptor = NSSortDescriptor(key: "startTime", ascending: false)
+        fetchRequest.sortDescriptors = [sortDescriptor]
         do {
             let rides = try context.fetch(fetchRequest)
             return rides.map { ride in

--- a/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
+++ b/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
@@ -33,10 +33,17 @@ struct RideRouteMapView: View {
     
     var body: some View {
         if route.isEmpty {
-            Text("경로 없음")
-                .font(.title)
-                .foregroundColor(.secondary)
-                .frame(height: 300)
+            VStack(spacing: 18){
+                
+                Image(systemName: "mappin.slash")
+                    .font(.system(size: 40))
+                    .foregroundColor(.gray)
+                
+                Text("주행 경로가 없습니다")
+                    .customFont(.subInfoTitle)
+                    
+            }
+            .frame(height: 300)
         } else {
             Map(position: $position) {
                 MapPolyline(coordinates: route)

--- a/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
+++ b/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
@@ -132,30 +132,6 @@ struct RideRouteMapView: View {
     }
 }
 
-struct StartPoint: View {
-    var body: some View {
-        ZStack {
-            Circle()
-                .fill(Color.green)
-                .frame(width: 30, height: 30)
-            Image(systemName: "figure.walk")
-                .foregroundColor(.white)
-        }
-    }
-}
-
-struct EndPoint: View {
-    var body: some View {
-        ZStack {
-            Circle()
-                .fill(Color.red)
-                .frame(width: 30, height: 30)
-            Image(systemName: "flag.checkered")
-                .foregroundColor(.white)
-        }
-    }
-}
-
 struct RideRouteMapView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
+++ b/DomadoV/DomadoV/View/Component/RideRouteMapView.swift
@@ -10,20 +10,18 @@ import MapKit
 
 
 struct RideRouteMapView: View {
-    let route: [CLLocationCoordinate2D]
+    let routes: [[CLLocationCoordinate2D]]
     @State private var position: MapCameraPosition
     
-    init(route: [CLLocationCoordinate2D]) {
-        self.route = route
+    init(route: [CLLocationCoordinate2D], maxDistanceGap: CLLocationDistance = 100) {
+        self.routes = Self.splitRoute(route, maxDistanceGap: maxDistanceGap)
         
-        // 초기 위치 설정
         if let firstCoordinate = route.first {
             _position = State(initialValue: .region(MKCoordinateRegion(
                 center: firstCoordinate,
                 span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
             )))
         } else {
-            // 기본 위치 설정 (예: 서울)
             _position = State(initialValue: .region(MKCoordinateRegion(
                 center: CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780),
                 span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
@@ -32,51 +30,92 @@ struct RideRouteMapView: View {
     }
     
     var body: some View {
-        if route.isEmpty {
+        if routes.isEmpty {
             VStack(spacing: 18){
-                
                 Image(systemName: "mappin.slash")
                     .font(.system(size: 40))
                     .foregroundColor(.gray)
                 
-                Text("주행 경로가 없습니다")
+                Text("유효한 주행 경로가 없습니다")
                     .customFont(.subInfoTitle)
-                    
             }
             .frame(height: 300)
         } else {
             Map(position: $position) {
-                MapPolyline(coordinates: route)
-                    .stroke(
-                        .lavenderPurple,
-                        style: StrokeStyle(
-                            lineWidth: 8,
-                            lineCap: .round,
-                            lineJoin: .round
+                ForEach(routes.indices, id: \.self) { index in
+                    let route = routes[index]
+                    MapPolyline(coordinates: route)
+                        .stroke(
+                            .lavenderPurple,
+                            style: StrokeStyle(
+                                lineWidth: 8,
+                                lineCap: .round,
+                                lineJoin: .round
+                            )
                         )
-                    )
                     
+                    if index == 0, let startPoint = route.first {
+                        Marker("시작", coordinate: startPoint)
+                            .tint(.electricBlue)
+                    }
+                    
+                    if index == routes.count - 1, let endPoint = route.last {
+                        Marker("도착", coordinate: endPoint)
+                            .tint(.sunsetOrange)
+                    }
+                }
             }
             .frame(height: 300)
             .onAppear {
-                setRegionToFitRoute()
+                setRegionToFitAllRoutes()
             }
         }
     }
     
-    private func setRegionToFitRoute() {
-        guard !route.isEmpty else { return }
+    private static func splitRoute(_ route: [CLLocationCoordinate2D], maxDistanceGap: CLLocationDistance) -> [[CLLocationCoordinate2D]] {
+        var routes: [[CLLocationCoordinate2D]] = []
+        var currentSegment: [CLLocationCoordinate2D] = []
         
-        var minLat = route[0].latitude
-        var maxLat = route[0].latitude
-        var minLon = route[0].longitude
-        var maxLon = route[0].longitude
+        for (index, coordinate) in route.enumerated() {
+            if index == 0 {
+                currentSegment.append(coordinate)
+                continue
+            }
+            
+            let previousCoordinate = route[index - 1]
+            let distance = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+                .distance(from: CLLocation(latitude: previousCoordinate.latitude, longitude: previousCoordinate.longitude))
+            
+            if distance > maxDistanceGap && !currentSegment.isEmpty {
+                routes.append(currentSegment)
+                currentSegment = [coordinate]
+            } else {
+                currentSegment.append(coordinate)
+            }
+        }
         
-        for coordinate in route {
-            minLat = min(minLat, coordinate.latitude)
-            maxLat = max(maxLat, coordinate.latitude)
-            minLon = min(minLon, coordinate.longitude)
-            maxLon = max(maxLon, coordinate.longitude)
+        if !currentSegment.isEmpty {
+            routes.append(currentSegment)
+        }
+        
+        return routes
+    }
+    
+    private func setRegionToFitAllRoutes() {
+        guard !routes.isEmpty else { return }
+        
+        var minLat = Double.greatestFiniteMagnitude
+        var maxLat = -Double.greatestFiniteMagnitude
+        var minLon = Double.greatestFiniteMagnitude
+        var maxLon = -Double.greatestFiniteMagnitude
+        
+        for route in routes {
+            for coordinate in route {
+                minLat = min(minLat, coordinate.latitude)
+                maxLat = max(maxLat, coordinate.latitude)
+                minLon = min(minLon, coordinate.longitude)
+                maxLon = max(maxLon, coordinate.longitude)
+            }
         }
         
         let center = CLLocationCoordinate2D(
@@ -93,10 +132,34 @@ struct RideRouteMapView: View {
     }
 }
 
+struct StartPoint: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.green)
+                .frame(width: 30, height: 30)
+            Image(systemName: "figure.walk")
+                .foregroundColor(.white)
+        }
+    }
+}
+
+struct EndPoint: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.red)
+                .frame(width: 30, height: 30)
+            Image(systemName: "flag.checkered")
+                .foregroundColor(.white)
+        }
+    }
+}
+
 struct RideRouteMapView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            // 경로가 있는 경우
+            // 연속적인 경로가 있는 경우
             RideRouteMapView(route: [
                 CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780),
                 CLLocationCoordinate2D(latitude: 37.5668, longitude: 126.9782),
@@ -114,7 +177,25 @@ struct RideRouteMapView_Previews: PreviewProvider {
                 CLLocationCoordinate2D(latitude: 37.5698, longitude: 126.9813),
                 CLLocationCoordinate2D(latitude: 37.5700, longitude: 126.9815)
             ])
-            .previewDisplayName("With Route")
+            .previewDisplayName("Continuous Route")
+
+            // 중간에 끊긴 경로가 있는 경우
+            RideRouteMapView(route: [
+                CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780),
+                CLLocationCoordinate2D(latitude: 37.5668, longitude: 126.9782),
+                CLLocationCoordinate2D(latitude: 37.5670, longitude: 126.9785),
+                CLLocationCoordinate2D(latitude: 37.5672, longitude: 126.9788),
+                CLLocationCoordinate2D(latitude: 37.5675, longitude: 126.9790),
+                // 큰 간격
+                CLLocationCoordinate2D(latitude: 37.5700, longitude: 126.9820),
+                CLLocationCoordinate2D(latitude: 37.5703, longitude: 126.9823),
+                CLLocationCoordinate2D(latitude: 37.5705, longitude: 126.9825),
+                // 다른 큰 간격
+                CLLocationCoordinate2D(latitude: 37.5730, longitude: 126.9855),
+                CLLocationCoordinate2D(latitude: 37.5733, longitude: 126.9858),
+                CLLocationCoordinate2D(latitude: 37.5735, longitude: 126.9860)
+            ], maxDistanceGap: 300)  // 300미터 이상의 간격을 끊김으로 간주
+            .previewDisplayName("Discontinuous Route")
 
             // 경로가 없는 경우
             RideRouteMapView(route: [])

--- a/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
+++ b/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
@@ -35,41 +35,59 @@ struct SpeedDistributionView: View {
     }
     
     var body: some View {
-        VStack(spacing: 0) {
-            GeometryReader { geometry in
-                let widths = calculateWidths(for: geometry.size.width)
-                
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(spacing: barSpacing) {
-                        ForEach(0..<segments.count, id: \.self) { index in
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(speedColors[index])
-                                .frame(width: widths[index], height: 30)
-                        }
+        VStack {
+            if segments.isEmpty {
+                emptyStateView
+            } else {
+                contentView
+            }
+        }
+        .frame(height: 90)
+        .padding(.vertical)
+    }
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "speedometer")
+                .font(.system(size: 40))
+                .foregroundColor(.gray)
+            Text("속도 분포 데이터가 없습니다")
+                .customFont(.subInfoTitle)
+        }
+    }
+    
+    private var contentView: some View {
+        GeometryReader { geometry in
+            let widths = calculateWidths(for: geometry.size.width)
+            
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: barSpacing) {
+                    ForEach(0..<segments.count, id: \.self) { index in
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(speedColors[index])
+                            .frame(width: widths[index], height: 30)
                     }
-                    
-                    HStack(spacing: barSpacing) {
-                        ForEach(0..<segments.count, id: \.self) { index in
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack(spacing: 4) {
-                                    Text(speedLabels[index])
-                                        .customFont(.subInfoTitle)
-                                    Circle()
-                                        .fill(speedColors[index])
-                                        .frame(width: circleSize, height: circleSize)
-                                }
-                                Text(segments[index].time > 0 ? segments[index].time.formatTimeInMinutes() : "-")
-                                    .customFont(.supplementaryTimeDistanceNumber)
-                                    .foregroundColor(colorScheme == .dark ? .white : .black)
+                }
+                
+                HStack(spacing: barSpacing) {
+                    ForEach(0..<segments.count, id: \.self) { index in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 4) {
+                                Text(speedLabels[index])
+                                    .customFont(.subInfoTitle)
+                                Circle()
+                                    .fill(speedColors[index])
+                                    .frame(width: circleSize, height: circleSize)
                             }
-                            .frame(width: widths[index])
-                            .frame(maxWidth: .infinity, alignment: .center)
+                            Text(segments[index].time > 0 ? segments[index].time.formatTimeInMinutes() : "-")
+                                .customFont(.supplementaryTimeDistanceNumber)
+                                .foregroundColor(colorScheme == .dark ? .white : .black)
                         }
+                        .frame(width: widths[index])
+                        .frame(maxWidth: .infinity, alignment: .center)
                     }
                 }
             }
-            .frame(height: 90)
-            .padding(.vertical)
         }
     }
 }
@@ -99,6 +117,14 @@ struct SpeedDistributionView_Previews: PreviewProvider {
             .padding()
             .preferredColorScheme(.dark)
             .previewDisplayName("Dark Mode with Zero Time")
+            
+            
+            SpeedDistributionView(
+                segments: []
+            )
+            .previewLayout(.sizeThatFits)
+            .padding()
+            .previewDisplayName("No Distribution")
         }
     }
 }

--- a/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
+++ b/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
@@ -1,0 +1,104 @@
+//
+//  SpeedDistributionView.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/19/24.
+//
+
+import SwiftUI
+
+struct SpeedDistributionView: View {
+    let segments: [(ratio: CGFloat, time: TimeInterval)]
+    let speedColors: [Color] = [.electricBlue, .lavenderPurple, .sunsetOrange ]
+    let speedLabels: [String] =  ["느림", "보통", "빠름"]
+    
+    @Environment(\.colorScheme) private var colorScheme
+    
+    private let barSpacing: CGFloat = 4
+    private let circleSize: CGFloat = 8
+    private let minSegmentWidth: CGFloat = 60 // 최소 세그먼트 너비
+    
+    private func calculateWidths(for size: CGFloat) -> [CGFloat] {
+        let totalWidth = size - (CGFloat(segments.count - 1) * barSpacing)
+        let totalMinWidth = CGFloat(segments.count) * minSegmentWidth
+        
+        if totalWidth <= totalMinWidth {
+            return Array(repeating: minSegmentWidth, count: segments.count)
+        }
+        
+        let remainingWidth = totalWidth - totalMinWidth
+        let totalRatio = segments.reduce(0) { $0 + $1.ratio }
+        
+        return segments.map { segment in
+            minSegmentWidth + (remainingWidth * (segment.ratio / totalRatio))
+        }
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            GeometryReader { geometry in
+                let widths = calculateWidths(for: geometry.size.width)
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: barSpacing) {
+                        ForEach(0..<segments.count, id: \.self) { index in
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(speedColors[index])
+                                .frame(width: widths[index], height: 30)
+                        }
+                    }
+                    
+                    HStack(spacing: barSpacing) {
+                        ForEach(0..<segments.count, id: \.self) { index in
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(spacing: 4) {
+                                    Text(speedLabels[index])
+                                        .customFont(.subInfoTitle)
+                                    Circle()
+                                        .fill(speedColors[index])
+                                        .frame(width: circleSize, height: circleSize)
+                                }
+                                Text(segments[index].time > 0 ? segments[index].time.formatTimeInMinutes() : "-")
+                                    .customFont(.supplementaryTimeDistanceNumber)
+                                    .foregroundColor(colorScheme == .dark ? .white : .black)
+                            }
+                            .frame(width: widths[index])
+                            .frame(maxWidth: .infinity, alignment: .center)
+                        }
+                    }
+                }
+            }
+            .frame(height: 90)
+            .padding(.vertical)
+        }
+    }
+}
+
+struct SpeedDistributionView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            SpeedDistributionView(
+                segments: [
+                    (ratio: 0.3, time: 3600),
+                    (ratio: 0.5, time: 7200),
+                    (ratio: 0.2, time: 1800)
+                ]
+            )
+            .previewLayout(.sizeThatFits)
+            .padding()
+            .previewDisplayName("Light Mode")
+
+            SpeedDistributionView(
+                segments: [
+                    (ratio: 0, time: 0),
+                    (ratio: 0.8, time: 3600),
+                    (ratio: 0.2, time: 1800)
+                ]
+            )
+            .previewLayout(.sizeThatFits)
+            .padding()
+            .preferredColorScheme(.dark)
+            .previewDisplayName("Dark Mode with Zero Time")
+        }
+    }
+}

--- a/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
+++ b/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct SpeedDistributionView: View {
-    let segments: [(ratio: CGFloat, time: TimeInterval)]
-    let speedColors: [Color] = [.electricBlue, .lavenderPurple, .sunsetOrange ]
-    let speedLabels: [String] =  ["느림", "보통", "빠름"]
+    let segments: [(ratio: Double, time: TimeInterval)]
+    let speedColors: [Color] = [.electricBlue, .lavenderPurple, .sunsetOrange]
+    let speedLabels: [String] = ["느림", "보통", "빠름"]
     
     @Environment(\.colorScheme) private var colorScheme
     
@@ -27,10 +27,10 @@ struct SpeedDistributionView: View {
         }
         
         let remainingWidth = totalWidth - totalMinWidth
-        let totalRatio = segments.reduce(0) { $0 + $1.ratio }
+        let totalRatio = segments.reduce(0.0) { $0 + $1.ratio }
         
         return segments.map { segment in
-            minSegmentWidth + (remainingWidth * (segment.ratio / totalRatio))
+            minSegmentWidth + (remainingWidth * CGFloat(segment.ratio / totalRatio))
         }
     }
     
@@ -90,7 +90,7 @@ struct SpeedDistributionView_Previews: PreviewProvider {
 
             SpeedDistributionView(
                 segments: [
-                    (ratio: 0, time: 0),
+                    (ratio: 0.0, time: 0),
                     (ratio: 0.8, time: 3600),
                     (ratio: 0.2, time: 1800)
                 ]

--- a/DomadoV/DomadoV/View/RideHistoryCell.swift
+++ b/DomadoV/DomadoV/View/RideHistoryCell.swift
@@ -55,7 +55,7 @@ struct RideHistoryCell: View {
             Image(systemName: "point.topleft.down.to.point.bottomright.curvepath")
                 .customFont(.listNumber)
                 .foregroundColor(.midnightCharcoal)
-            Text("\(Int(ride.totalDistance)) km")
+            Text("\(ride.totalDistance.formatToDecimal(1)) km")
                 .customFont(.listNumber)
                 .foregroundColor(.midnightCharcoal)
         }

--- a/DomadoV/DomadoV/View/RideHistoryCell.swift
+++ b/DomadoV/DomadoV/View/RideHistoryCell.swift
@@ -9,8 +9,7 @@ import SwiftUI
 
 struct RideHistoryCell: View {
     
-    let workout: RideHistoryModel
-    
+    let ride: RideRecord
     
     var body: some View {
         HStack {
@@ -26,9 +25,9 @@ struct RideHistoryCell: View {
     
     private var workoutInfo: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(workout.date)
+            Text(ride.startTime.formatAsKoreanDate(option: .dateOnly))
                 .customFont(.supplementaryTimeDistanceNumber)
-            Text(workout.day)
+            Text(ride.startTime.formatAsKoreanDate(option: .dayOfWeekOnly))
                 .customFont(.infoTitle)
                 .foregroundColor(.midnightCharcoal)
             
@@ -39,14 +38,13 @@ struct RideHistoryCell: View {
         }
     }
     
-    
-    
+
     private var timeInfo: some View {
         HStack(spacing: 2) {
             Image(systemName: "clock")
                 .customFont(.listNumber)
                 .foregroundColor(.midnightCharcoal)
-            Text("\(workout.startTime) - \(workout.endTime)")
+            Text("\(ride.startTime.formatAsKoreanTime(option: .hourMinute)) - \(ride.endTime.formatAsKoreanTime(option: .hourMinute))")
                 .customFont(.listNumber)
                 .foregroundColor(.midnightCharcoal)
         }
@@ -57,7 +55,7 @@ struct RideHistoryCell: View {
             Image(systemName: "point.topleft.down.to.point.bottomright.curvepath")
                 .customFont(.listNumber)
                 .foregroundColor(.midnightCharcoal)
-            Text("\(workout.distance) km")
+            Text("\(Int(ride.totalDistance)) km")
                 .customFont(.listNumber)
                 .foregroundColor(.midnightCharcoal)
         }
@@ -68,9 +66,9 @@ struct RideHistoryCell: View {
     
     private var speedInfo: some View {
         HStack(alignment: .lastTextBaseline, spacing: 1) {
-            Text("\(workout.speed)")
+            Text("\(Int(ride.averageSpeed))")
                 .customFont(.baseTimeDistanceNumber)
-                .foregroundColor(speedColor(speed: workout.speed))
+                .foregroundColor(speedColor(speed: ride.averageSpeed))
             VStack(alignment: .leading, spacing: 0) {
                 Text("km/h")
                     .customFont(.listNumber)
@@ -90,7 +88,7 @@ struct RideHistoryCell: View {
 
     //MARK: - Speedcolor
     
-    private func speedColor(speed: Int) -> Color {
+    private func speedColor(speed: Double) -> Color {
         switch speed {
         case 0...20: return .electricBlue
         case 21...35: return .lavenderPurple
@@ -100,6 +98,25 @@ struct RideHistoryCell: View {
 }
 
 
-#Preview {
-    RideHistoryCell(workout: RideHistoryModel(date: "2024. 10. 6", day: "금요일", startTime: "09:56", endTime: "14:37", distance: 452, speed: 21))
+struct RideHistoryCell_Previews: PreviewProvider {
+    static var previews: some View {
+        let sampleRide = RideRecord(
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(3600), // 1 hour later
+            totalDistance: 25.5,
+            totalRidingTime: 3300, // 55 minutes
+            targetSpeedLower: 15,
+            targetSpeedUpper: 25,
+            timeInSlowZone: 600,
+            timeInTargetZone: 2400,
+            timeInFastZone: 300,
+            route: []
+        )
+        
+        return VStack {
+            RideHistoryCell(ride: sampleRide)
+        }
+        .previewLayout(.sizeThatFits)
+    }
 }
+

--- a/DomadoV/DomadoV/View/RideHistoryView.swift
+++ b/DomadoV/DomadoV/View/RideHistoryView.swift
@@ -16,18 +16,10 @@ struct RideHistoryView: View {
     
     
     // Properties
-    
     @ObservedObject var vm: RideHistoryViewModel
-    
-    let record = [
-        RideHistoryModel(date: "2024. 10. 6", day: "금요일", startTime: "09:56", endTime: "14:37", distance: 452, speed: 21),
-        RideHistoryModel(date: "2024. 10. 6", day: "금요일", startTime: "09:56", endTime: "14:37", distance: 452, speed: 40),
-        RideHistoryModel(date: "2024. 10. 6", day: "금요일", startTime: "09:56", endTime: "14:37", distance: 452, speed: 5)
-    ]
     
     
     // Body
-    
     var body: some View {
         NavigationView {
             VStack(spacing: 1) {
@@ -80,19 +72,6 @@ struct RideHistoryView: View {
             }
         }
     }
-}
-
-
-    //MARK: - Model
-
-struct RideHistoryModel: Identifiable {
-    let id = UUID()
-    let date: String
-    let day: String
-    let startTime: String
-    let endTime: String
-    let distance: Int
-    let speed: Int
 }
 
 

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -16,11 +16,7 @@ import SwiftUI
 /// 5. 닫기 버튼을 눌러 주행준비 화면으로 돌아갑니다.
 struct RideSummaryView: View {
     @ObservedObject var vm: RideSummaryViewModel
-    
-    private let speedLabels = ["목표 속도 미만", "목표 속도 내", "목표 속도 초과"]
-    private let speedColors: [Color] = [.blue, .green, .red]
-    private let barSpacing: CGFloat = 4
-    
+
     var body: some View {
         VStack(spacing: 20) {
             Text("주행 요약")
@@ -29,11 +25,11 @@ struct RideSummaryView: View {
             if let summary = vm.rideSummary {
                 VStack(alignment: .leading, spacing: 10) {
                     Text("총 거리: \(summary.totalDistance, specifier: "%.2f") km")
-                    Text("총 시간: \(vm.formatTime(summary.totalTime))")
+                    Text("총 시간: \(summary.totalTime.formatTime())")
                     
                     
-                    Text("총 주행시간: \(vm.formatTime(summary.totalRideTime)) ")
-                    Text("총 휴식 시간: \(vm.formatTime(summary.totalRestTime))")
+                    Text("총 주행시간: \(summary.totalRideTime.formatTime())")
+                    Text("총 휴식 시간: \(summary.totalRestTime.formatTime())")
                     
                     
                     Text("평균 속도: \(summary.averageSpeed, specifier: "%.1f") km/h")
@@ -44,53 +40,10 @@ struct RideSummaryView: View {
                     .font(.headline)
                     .padding(.top)
                 
-                let segments = vm.calculateSpeedDistribution()
+                // MARK: 속도분포
+                SpeedDistributionView(segments: vm.getSpeedDistribution())
+               
                 
-                GeometryReader { geometry in
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack(spacing: barSpacing) {
-                            ForEach(0..<segments.count, id: \.self) { index in
-                                VStack(spacing: 4) {
-                                    RoundedRectangle(cornerRadius: 12)
-                                        .fill(speedColors[index])
-                                        .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio, height: 30)
-                                    
-                                    Text(vm.formatTime(segments[index].time))
-                                        .font(.caption)
-                                        .foregroundColor(.black)
-                                }
-                            }
-                        }
-                        
-                        HStack(spacing: 0) {
-                            ForEach(0..<segments.count, id: \.self) { index in
-                                Text(speedLabels[index])
-                                    .font(.caption)
-                                    .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio)
-                                    .multilineTextAlignment(.center)
-                                
-                                if index < segments.count - 1 {
-                                    Spacer().frame(width: barSpacing)
-                                }
-                            }
-                        }
-                        .padding(.top, 4)
-                    }
-                }
-                .frame(height: 80)
-                .padding(.vertical)
-                
-                VStack(alignment: .leading, spacing: 5) {
-                    ForEach(0..<segments.count, id: \.self) { index in
-                        HStack {
-                            Circle()
-                                .fill(speedColors[index])
-                                .frame(width: 10, height: 10)
-                            Text("\(speedLabels[index]): \(vm.formatTime(segments[index].time)) (\(Int(segments[index].ratio * 100))%)")
-                        }
-                    }
-                }
-                .padding(.top)
             } else {
                 Text("주행 요약 정보를 불러오는 중...")
             }

--- a/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideHistoryViewModel.swift
@@ -10,7 +10,8 @@ import Combine
 class RideHistoryViewModel: ObservableObject, RideEventPublishable {
     
     @Published var records: [RideRecord] = []
-    
+    @Published var selectedRide: RideRecord?
+
     private let rideHistoryManager: RideHistoryManager
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
     let rideEventSubject = PassthroughSubject<RideEvent, Never>()
@@ -24,5 +25,14 @@ class RideHistoryViewModel: ObservableObject, RideEventPublishable {
     func returnToPreparation() {
         rideEventSubject.send(.didReturnToPreparation)
     }
-
+    
+    func deleteRecord(_ record: RideRecord) {
+        rideHistoryManager.deleteRide(id: record.id)
+        
+        if let index = records.firstIndex(where: { $0.id == record.id }) {
+            records.remove(at: index)
+        }
+    }
+    
+    
 }

--- a/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
@@ -54,10 +54,4 @@ class RideSummaryViewModel: ObservableObject, RideEventPublishable {
         ]
     }
     
-    func formatTime(_ seconds: TimeInterval) -> String {
-        let hours = Int(seconds) / 3600
-        let minutes = (Int(seconds) % 3600) / 60
-        let remainingSeconds = Int(seconds) % 60
-        return String(format: "%02d:%02d:%02d", hours, minutes, remainingSeconds)
-    }
 }

--- a/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
@@ -31,27 +31,12 @@ class RideSummaryViewModel: ObservableObject, RideEventPublishable {
         rideSummary = rideSession.generateRideSummary()
      }
     
-    func calculateSpeedDistribution() -> [(ratio: Double, time: TimeInterval)] {
-        guard let summary = rideSummary, summary.totalTime > 0 else {
-            return []
-        }
+    /// SpeedDistribution을 이용해 각 속도 구간별 비율과 시간을 계산해서 반환합니다.
+    func getSpeedDistribution() -> [(ratio: Double, time: TimeInterval)] {
         
-        let distribution = summary.speedDistribution
-        let totalTargetTime = distribution.belowTarget + distribution.withinTarget + distribution.aboveTarget
+        guard let summary = self.rideSummary else { return [] }
         
-        guard totalTargetTime > 0 else {
-            return []
-        }
-        
-        let belowRatio = distribution.belowTarget / totalTargetTime
-        let withinRatio = distribution.withinTarget / totalTargetTime
-        let aboveRatio = distribution.aboveTarget / totalTargetTime
-        
-        return [
-            (belowRatio, summary.totalTime * belowRatio),
-            (withinRatio, summary.totalTime * withinRatio),
-            (aboveRatio, summary.totalTime * aboveRatio)
-        ]
+        return SpeedDistribution.calculateSpeedDistribution(speedDistribution: summary.speedDistribution, totalTime: summary.totalTime)
     }
     
 }

--- a/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RideSummaryViewModel.swift
@@ -36,7 +36,7 @@ class RideSummaryViewModel: ObservableObject, RideEventPublishable {
         
         guard let summary = self.rideSummary else { return [] }
         
-        return SpeedDistribution.calculateSpeedDistribution(speedDistribution: summary.speedDistribution, totalTime: summary.totalTime)
+        return SpeedDistribution.calculateSpeedDistribution(speedDistribution: summary.speedDistribution, totalTime: summary.totalRideTime)
     }
     
 }


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- 날짜 포멧팅을 위한 Date Extension 추가
- 거리 포멧팅을 위한 Double Extension 추가
- 시간 포멧팅을 위한 TimeInterval Extension 추가
- RideRecord 구조체 Hashable 채택 및 평균속도 계산시 guard 로 발산하는 경우 예방 
- SpeedDistribution에 구간별 속도 비율 계산 static 메서드 추가
- RideSummaryViewModel에서 속도 분포를 SpeedDistribution의 static 메서드를 통해 얻도록 함 
- RideHistoryViewModel에 주행기록 삭제 메서드 추가 
- SpeedDistributionView 속도분포 뷰 컴포넌트 추가 
- RideRouteMapView 시작위치, 도착위치 표시및 경로 끓긴 경우에 대한 처리 
- Ride 엔티티 fetch시 최근 주행순으로 가져오기
- RideSummaryView에서 SpeedDistributionView 사용 
- 주행기록 View에 RideRecord 를 사용하는 방식으로 변경 

## 🟠 변경 이유 (Why)
사용자에게 주행기록을 보여줍니다 .


## 🔵 스크린샷 (Visual Proof) 
<img src="https://github.com/user-attachments/assets/cc1ccbb0-19e5-4b0e-9e12-c4c5ce5b7531" width="270"/>
<img src="https://github.com/user-attachments/assets/94cf88d6-ff0f-414e-b830-e8e0a4a2f2ed" width="270"/>


## 🟢 추가 노트 (Additional Notes)
- 뷰와 관련해서 날짜, 거리, 시간에 대해 포멧팅 extension을 활용하도록 바꾸었습니다. 
- 주행기록 뷰에 대해 상당부분이 바뀌어 기존 작업 상황과 충돌이 생길수도 있습니다. 
