### PR TITLE
[feat] 휴식 화면 실제 정보 표시 

### DIFF
--- a/DomadoV/DomadoV/View/PauseRideView.swift
+++ b/DomadoV/DomadoV/View/PauseRideView.swift
@@ -80,7 +80,7 @@ struct PauseRideView: View {
             Text("휴식 시간")
                 .customFont(.infoTitle)
                 .frame(maxWidth: .infinity, alignment: .center)
-            Text("12:45")
+            Text(vm.restTime.formatTime())
                 .customFont(.paceSettingNumber)
                 .frame(maxWidth: .infinity, alignment: .center)
         }

--- a/DomadoV/DomadoV/View/PauseRideView.swift
+++ b/DomadoV/DomadoV/View/PauseRideView.swift
@@ -52,7 +52,7 @@ struct PauseRideView: View {
                     .customFont(.infoTitle)
                 Spacer()
             }
-            Text("105 km")
+            Text(vm.currentDistance.formatToDecimal(2) + " km")
                 .customFont(.baseTimeDistanceNumber)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -67,7 +67,7 @@ struct PauseRideView: View {
                 Text("시간")                                .customFont(.infoTitle)
                 Spacer()
             }
-            Text("01:30:27")
+            Text(vm.currentRidingTime.formatTime())
                 .customFont(.baseTimeDistanceNumber)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
@@ -6,9 +6,13 @@
 //
 
 import Combine
+import Foundation
 
 /// 주행정지 화면에 대한 정보와 동작을 관리합니다. 
 class PauseRideViewModel: ObservableObject, RideEventPublishable {
+    
+    let currentDistance: Double
+    let currentRidingTime: TimeInterval
     
     let rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
@@ -16,6 +20,8 @@ class PauseRideViewModel: ObservableObject, RideEventPublishable {
     
     init(rideSession: RideSession) {
         self.rideSession = rideSession
+        self.currentDistance = rideSession.totalDistance
+        self.currentRidingTime = rideSession.totalRideTime
     }
     
     func resumeRide(){

--- a/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/PauseRideViewModel.swift
@@ -13,6 +13,9 @@ class PauseRideViewModel: ObservableObject, RideEventPublishable {
     
     let currentDistance: Double
     let currentRidingTime: TimeInterval
+    @Published var restTime: TimeInterval = 0
+    
+    private var timer: Timer?
     
     let rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
@@ -22,15 +25,31 @@ class PauseRideViewModel: ObservableObject, RideEventPublishable {
         self.rideSession = rideSession
         self.currentDistance = rideSession.totalDistance
         self.currentRidingTime = rideSession.totalRideTime
+        startRestTimer()
     }
     
+    deinit { stopRestTimer() }
+    
     func resumeRide(){
+        stopRestTimer()
         rideEventSubject.send(.didResumeRide)
         rideSession.resume()
     }
     
     func finishRide(){
+        stopRestTimer()
         rideEventSubject.send(.didFinishRide)
         rideSession.stop()
+    }
+    
+    private func startRestTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.restTime += 1
+        }
+    }
+        
+    private func stopRestTimer() {
+        timer?.invalidate()
+        timer = nil
     }
 }


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- PuaseRideView에서 viewModel로부터 정보를 받아와 표시하도록 했습니다. 
- viewModel에 거리와 주행 시간에 대한 프로퍼티를 추가한뒤, vm 초기화시 RideSession으로부터 해당 값을 받아오도록 하였습니다.
- viewModel에 타이머를 추가하여 현재 세션의 휴식시간을 표시합니다. 
- RideSession의 전체 휴식시간 계산로직을 수정하였습니다. 

## 🟠 변경 이유 (Why)
- 사용자에게 현재까지의 주행시간, 주행거리를 표시해주고 현재 세션의 경과 휴식시간을 보여줍니다. 

## 🟢 추가 노트 (Additional Notes)
- 기존의 휴식시간 로직은 pause가 다시 resume될때만 현재 휴식시간을 더했기 때문에 마지막 휴식세션의 휴식시간이 계산에 포함되지 않는 현상이 있어서 전체 휴식시간을 연산프로퍼티로 변경한후 전체 휴식시간은 마지막 휴식시간까지 고려하여 계산하도록 하였습니다. 

close #43