### PR TITLE
[feat] 주행시작전 카운트 다운

### DIFF
--- a/DomadoV/DomadoV/App/ContentView.swift
+++ b/DomadoV/DomadoV/App/ContentView.swift
@@ -22,6 +22,12 @@ struct ContentView: View {
                 .onAppear{
                     coordinator.rideSession = rideSession
                     coordinator.bind(to: vm)}
+        case .countdown:
+            if let rideSession = coordinator.rideSession {
+                let vm = CountdownViewModel(rideSession: rideSession)
+                CountdownView(vm: vm)
+                    .onAppear{coordinator.bind(to: vm)}
+            }
         case .active:
             if let rideSession = coordinator.rideSession {
                 let vm = ActiveRideViewModel(rideSession: rideSession)

--- a/DomadoV/DomadoV/Coordinator/AppCoordinator .swift
+++ b/DomadoV/DomadoV/Coordinator/AppCoordinator .swift
@@ -32,6 +32,8 @@ class AppCoordinator: ObservableObject{
     /// viewModel로부터 Event를 받아 화면을 전환합니다.
     private func handleRideEvent(_ event: RideEvent) {
         switch event {
+        case .didStartCountdown:
+            currentView = .countdown
         case .didStartRide:
             currentView = .active
         case .didPauseRide:

--- a/DomadoV/DomadoV/Coordinator/AppView.swift
+++ b/DomadoV/DomadoV/Coordinator/AppView.swift
@@ -9,6 +9,8 @@
 enum AppView {
     /// 주행 시작
     case preparation
+    /// 카운트 다운
+    case countdown
     /// 주행 중
     case active
     /// 주행 정지

--- a/DomadoV/DomadoV/Coordinator/RideEvent.swift
+++ b/DomadoV/DomadoV/Coordinator/RideEvent.swift
@@ -9,7 +9,9 @@
 ///
 /// AppCoordinator는 다음 event들을 구독하여 뷰를 교체합니다.
 enum RideEvent {
-    /// 준비화면 -> 주행화면
+    /// 준비화면 -> 카운트다운화면
+    case didStartCountdown
+    /// 카운트다운화면 -> 주행화면
     case didStartRide
     /// 주행화면 -> 정지화면
     case didPauseRide

--- a/DomadoV/DomadoV/Model/RideSession.swift
+++ b/DomadoV/DomadoV/Model/RideSession.swift
@@ -103,10 +103,14 @@ class RideSession {
             .eraseToAnyPublisher()
     }
     
+    /// 목표 속도 범위 설정
+    func setTargetSpeedRange(_ range: ClosedRange<Double>) {
+        targetSpeedRange = range
+    }
+    
     /// 주행시작
-    func start(settedtargetSpeedRange: ClosedRange<Double>) {
+    func start() {
         guard state == .preparation else { return }
-        targetSpeedRange = settedtargetSpeedRange
         startTime = Date()
         state = .active
         startTimer()

--- a/DomadoV/DomadoV/View/CountdownView.swift
+++ b/DomadoV/DomadoV/View/CountdownView.swift
@@ -1,0 +1,41 @@
+//
+//  CountdownView.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/20/24.
+//
+
+import SwiftUI
+
+struct CountdownView: View {
+    @ObservedObject var vm: CountdownViewModel
+    
+    var body: some View {
+        ZStack {
+            // 배경 원
+            Circle()
+                .stroke(Color.gray.opacity(0.3), lineWidth: 10)
+            
+            // 채워진 부분
+            Circle()
+                .trim(from: 0, to: CGFloat(vm.countdownTime) / 3.0)
+                .stroke(.sunsetOrange, style: StrokeStyle(lineWidth: 10, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut(duration: 1), value: vm.countdownTime)
+            
+            // 카운트다운 숫자
+            Text("\(vm.countdownTime)")
+                .customFont(.paceSettingNumber)
+        }
+        .frame(width: 300, height: 300)
+        .onAppear {
+            vm.startCountdown()
+        }
+    }
+}
+
+struct CountdownView_Previews: PreviewProvider {
+    static var previews: some View {
+        CountdownView(vm: CountdownViewModel(rideSession: RideSession()))
+    }
+}

--- a/DomadoV/DomadoV/ViewModel/CountdonwViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/CountdonwViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  CountdonwViewModel.swift
+//  DomadoV
+//
+//  Created by 이종선 on 10/20/24.
+//
+
+import Combine
+import Foundation
+
+class CountdownViewModel: ObservableObject, RideEventPublishable {
+    @Published var countdownTime: Int = 3
+    var rideEventSubject = PassthroughSubject<RideEvent, Never>()
+    private var timer: Timer?
+    private let rideSession: RideSession
+    
+    init(rideSession: RideSession) {
+        self.rideSession = rideSession
+    }
+    
+    func startCountdown() {
+        countdownTime = 3
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] timer in
+            guard let self = self else { return }
+            if self.countdownTime > 0 {
+                self.countdownTime -= 1
+            } else {
+                self.stopCountdown()
+                self.startRide()
+            }
+        }
+    }
+    
+    func stopCountdown() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    private func startRide() {
+        rideSession.start()
+        rideEventSubject.send(.didStartRide)
+    }
+    
+    deinit {
+        stopCountdown()
+    }
+}

--- a/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/RidePreparationViewModel.swift
@@ -35,8 +35,8 @@ class RidePreparationViewModel: ObservableObject, RideEventPublishable {
             showLocationPermissionAlert = true
             return
         }
-        rideEventSubject.send(.didStartRide)
-        rideSession.start(settedtargetSpeedRange: userSettingTargetSpeedRange)
+        rideSession.setTargetSpeedRange(userSettingTargetSpeedRange)
+        rideEventSubject.send(.didStartCountdown)       
     }
     
     /// 주행기록을 보여줍니다.


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `AppView`와 `RideEvent`에 Countdown 화면에 대한 케이스를 추가했습니다. 
- `RideSession`의 `start`메서드에서 속도범위 설정을 하는 부분을 별도의 메서드 `setTargetSpeedRange`로 분리했습니다. 
- `RidePreparationViewModel`에서 `startRide` 호출시 `RideSession의 `setTargetSpeedRange`메서드를 호출하여 속도 범위를 설정한뒤 카운트다운뷰로 이동합니다. 
- `CountdownViewModel`에서는 화면에 보여지는 남은 시간에 대한 카운트를 Timer를 통해 관리하고 카운팅이 완료되면 RideSession의 `start`메서드를 호출하여 주행을 시작하고 주행화면으로 이동합니다.  
- `CountdownView`는 현재 남은시간을 숫자와 원의 남은 부분을 통해 시각적으로 보여줍니다. 
- `AppCoordinator`와 `ContentView`에서 새로 추가된 countdown 케이스에 대한 화면 전환 로직을 추가했습니다.

## 🟠 변경 이유 (Why)
- 주행이 시작전 카운트다운을 통해 사용자에게 라이딩을 준비할 수 있는 시간을 제공합니다. 

## 🔵 스크린샷 (Visual Proof) 
<img src="https://github.com/user-attachments/assets/86594eac-2777-414c-95ba-7ecbad3a1c4f" width="270"/>


