### PR TITLE
[feat] 주행완료 화면 구현

### DIFF
--- a/DomadoV/DomadoV/Extension/Extension+TimeInterval.swift
+++ b/DomadoV/DomadoV/Extension/Extension+TimeInterval.swift
@@ -27,9 +27,9 @@ extension TimeInterval {
         let minutes = (Int(self) % 3600) / 60
         
         if hours > 0 {
-            return String(format: "%d시간 %02d분", hours, minutes)
+            return String(format: "%dh %02dm", hours, minutes)
         } else {
-            return String(format: "%d분", minutes)
+            return String(format: "%dm", minutes)
         }
     }
 }

--- a/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
+++ b/DomadoV/DomadoV/View/Component/SpeedDistributionView.swift
@@ -14,8 +14,8 @@ struct SpeedDistributionView: View {
     
     @Environment(\.colorScheme) private var colorScheme
     
-    private let barSpacing: CGFloat = 4
-    private let circleSize: CGFloat = 8
+    private let barSpacing: CGFloat = 8
+    private let circleSize: CGFloat = 7
     private let minSegmentWidth: CGFloat = 60 // 최소 세그먼트 너비
     
     private func calculateWidths(for size: CGFloat) -> [CGFloat] {
@@ -43,7 +43,6 @@ struct SpeedDistributionView: View {
             }
         }
         .frame(height: 90)
-        .padding(.vertical)
     }
     
     private var emptyStateView: some View {
@@ -60,31 +59,32 @@ struct SpeedDistributionView: View {
         GeometryReader { geometry in
             let widths = calculateWidths(for: geometry.size.width)
             
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: barSpacing) {
                     ForEach(0..<segments.count, id: \.self) { index in
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(speedColors[index])
-                            .frame(width: widths[index], height: 30)
-                    }
-                }
-                
-                HStack(spacing: barSpacing) {
-                    ForEach(0..<segments.count, id: \.self) { index in
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 4) {
-                                Text(speedLabels[index])
-                                    .customFont(.subInfoTitle)
-                                Circle()
-                                    .fill(speedColors[index])
-                                    .frame(width: circleSize, height: circleSize)
+                        VStack (spacing: 0) {
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(speedColors[index])
+                                .frame(width: widths[index], height: 17)
+                                .padding(.bottom, 17)
+                            
+                            VStack(alignment: .leading, spacing: 0){
+                                HStack(spacing: 6) {
+                                    Text(speedLabels[index])
+                                        .customFont(.subInfoTitle)
+                                        .foregroundStyle(.midnightCharcoal)
+                                    Circle()
+                                        .fill(speedColors[index])
+                                        .frame(width: circleSize, height: circleSize)
+                                }
+                                .padding(.bottom, 10)
+                                
+                                Text(segments[index].time > 0 ? segments[index].time.formatTimeInMinutes() : "-")
+                                    .customFont(.supplementaryTimeDistanceNumber)
+                                    .foregroundColor(colorScheme == .dark ? .white : .black)
+                                
                             }
-                            Text(segments[index].time > 0 ? segments[index].time.formatTimeInMinutes() : "-")
-                                .customFont(.supplementaryTimeDistanceNumber)
-                                .foregroundColor(colorScheme == .dark ? .white : .black)
                         }
-                        .frame(width: widths[index])
-                        .frame(maxWidth: .infinity, alignment: .center)
                     }
                 }
             }
@@ -105,7 +105,7 @@ struct SpeedDistributionView_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
             .padding()
             .previewDisplayName("Light Mode")
-
+            
             SpeedDistributionView(
                 segments: [
                     (ratio: 0.0, time: 0),

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -17,94 +17,128 @@ import SwiftUI
 struct RideSummaryView: View {
     @ObservedObject var vm: RideSummaryViewModel
     
-    private let speedLabels = ["목표 속도 미만", "목표 속도 내", "목표 속도 초과"]
+    private let speedLabels = ["느려", "적정", "빨라"]
     private let speedColors: [Color] = [.blue, .green, .red]
-    private let barSpacing: CGFloat = 4
+    private let barSpacing: CGFloat = 8
     
     var body: some View {
-        VStack(spacing: 20) {
-            Text("주행 요약")
-                .font(.largeTitle)
-            
-            if let summary = vm.rideSummary {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("총 거리: \(summary.totalDistance, specifier: "%.2f") km")
-                    Text("총 시간: \(vm.formatTime(summary.totalTime))")
-                    
-                    
-                    Text("총 주행시간: \(vm.formatTime(summary.totalRideTime)) ")
-                    Text("총 휴식 시간: \(vm.formatTime(summary.totalRestTime))")
-                    
-                    
-                    Text("평균 속도: \(summary.averageSpeed, specifier: "%.1f") km/h")
-                    
+        VStack(spacing: 0) {
+            VStack(spacing: 0) {
+                HStack {
+                    ZStack {
+                        Text("라이딩 종료")
+                        
+                        HStack {
+                            Spacer()
+                            
+                            Button {
+                                vm.dismissSummary()
+                            } label: {
+                                Image(systemName: "multiply")
+                            }
+                        }
+                    }
                 }
+                .frame(height: 42)
+                .padding(.bottom, 22)
                 
-                Text("속도 구간별 주행 시간")
-                    .font(.headline)
-                    .padding(.top)
-                
-                let segments = vm.calculateSpeedDistribution()
-                
-                GeometryReader { geometry in
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack(spacing: barSpacing) {
-                            ForEach(0..<segments.count, id: \.self) { index in
-                                VStack(spacing: 4) {
-                                    RoundedRectangle(cornerRadius: 12)
-                                        .fill(speedColors[index])
-                                        .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio, height: 30)
+                if let summary = vm.rideSummary {
+                    HStack {
+                        Text("평균 속도")
+                        Spacer()
+                    }
+                    .padding(.bottom, 22)
+                    
+                    HStack {
+                        Spacer()
+                        Text("\(summary.averageSpeed, specifier: "%.1f")")
+                        Text("km/h")
+                        
+                    }
+                    .padding(.bottom, 45)
+                    
+                    // 속도 구간별 주행 시간
+                    let segments = vm.calculateSpeedDistribution()
+                    
+                    GeometryReader { geometry in
+                        VStack(alignment: .leading, spacing: 0) {
+                            HStack(spacing: barSpacing) {
+                                ForEach(0..<segments.count, id: \.self) { index in
+                                    VStack(spacing: 0) {
+                                        RoundedRectangle(cornerRadius: 5)
+                                            .fill(speedColors[index])
+                                            .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio, height: 17)
+                                            .padding(.bottom, 17)
+                                        
+                                        VStack(alignment: .leading, spacing: 0){
+                                            HStack(spacing: 6) {
+                                                Text("\(speedLabels[index])")
+                                                    .customFont(.subInfoTitle)
+                                                Circle()
+                                                    .fill(speedColors[index])
+                                                    .frame(width: 7, height: 7)
+                                            }
+                                            .padding(.bottom, 10)
+                                            
+                                            
+                                            Text("\(vm.formatTime(segments[index].time))")
+                                            //                                            Text("(\(Int(segments[index].ratio * 100))%)")
+                                        }
+                                    }
                                     
-                                    Text(vm.formatTime(segments[index].time))
-                                        .font(.caption)
-                                        .foregroundColor(.black)
                                 }
                             }
+                            
+                        }
+                    }
+                    .frame(height: 80)
+                    .padding(.vertical)
+                    
+                    
+                    VStack(alignment: .leading, spacing: 0){
+                        Text("총 시간")
+                            .padding(.bottom, 10)
+                        Text("\(vm.formatTime(summary.totalTime))")
+                            .padding(.bottom, 24)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        
+                        HStack {
+                            VStack(alignment: .leading, spacing: 0){
+                                Text("총 주행시간")
+                                    .padding(.bottom, 8)
+                                Text("\(vm.formatTime(summary.totalRideTime)) ")
+                            }
+                            
+                            VStack(alignment: .leading, spacing: 0){
+                                Text("총 휴식 시간")
+                                    .padding(.bottom, 8)
+                                Text("\(vm.formatTime(summary.totalRestTime))")
+                            }
+                            .padding(.horizontal, 40)
                         }
                         
-                        HStack(spacing: 0) {
-                            ForEach(0..<segments.count, id: \.self) { index in
-                                Text(speedLabels[index])
-                                    .font(.caption)
-                                    .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio)
-                                    .multilineTextAlignment(.center)
-                                
-                                if index < segments.count - 1 {
-                                    Spacer().frame(width: barSpacing)
-                                }
-                            }
-                        }
-                        .padding(.top, 4)
                     }
+                    .padding(.vertical, 70)
+                    
+                    HStack {
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text("총 거리")
+                                .padding(.bottom, 10)
+                            Text("\(summary.totalDistance, specifier: "%.2f") km")
+                        }
+                        
+                        Spacer()
+                    }
+                    
+                } else {
+                    Text("주행 요약 정보를 불러오는 중...")
                 }
-                .frame(height: 80)
-                .padding(.vertical)
                 
-                VStack(alignment: .leading, spacing: 5) {
-                    ForEach(0..<segments.count, id: \.self) { index in
-                        HStack {
-                            Circle()
-                                .fill(speedColors[index])
-                                .frame(width: 10, height: 10)
-                            Text("\(speedLabels[index]): \(vm.formatTime(segments[index].time)) (\(Int(segments[index].ratio * 100))%)")
-                        }
-                    }
-                }
-                .padding(.top)
-            } else {
-                Text("주행 요약 정보를 불러오는 중...")
+                Spacer()
             }
-            
-            Button("완료") {
-                vm.dismissSummary()
-            }
-            .padding()
-            .background(Color.blue)
-            .foregroundColor(.white)
-            .cornerRadius(10)
-            .padding(.top)
+            .frame(maxHeight: .infinity)
         }
-        .padding()
+        .padding([.horizontal, .bottom], 30)
         .onAppear {
             vm.getSummary()
         }

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -16,39 +16,123 @@ import SwiftUI
 /// 5. 닫기 버튼을 눌러 주행준비 화면으로 돌아갑니다.
 struct RideSummaryView: View {
     @ObservedObject var vm: RideSummaryViewModel
-
+        
     var body: some View {
-        VStack(spacing: 20) {
-            Text("주행 요약")
-                .font(.largeTitle)
+        VStack(spacing: 0) {
+            HStack {
+                ZStack {
+                    Text("라이딩 종료")
+                        .customFont(.pageTitle)
+                        .foregroundColor(.midnightCharcoal)
+                    
+                    HStack {
+                        Spacer()
+                        
+                        Button {
+                            vm.dismissSummary()
+                        } label: {
+                            Image(systemName: "multiply")
+                                .frame(width: 16, height: 16)
+                                .foregroundColor(.midnightCharcoal)
+                                .opacity(0.3)
+                        }
+                    }
+                }
+                .frame(height: 42)
+            }
+            .padding([.bottom,.top], 22)
             
-            if let summary = vm.rideSummary {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("총 거리: \(summary.totalDistance, specifier: "%.2f") km")
-                    Text("총 시간: \(summary.totalTime.formatTime())")
+            VStack(spacing: 0) {
+                if let summary = vm.rideSummary {
+                    VStack(spacing: 0) {
+                        HStack {
+                            Text("평균 속도")
+                                .customFont(.infoTitle)
+                                .foregroundColor(.midnightCharcoal)
+                            Spacer()
+                        }
+                        .padding(.bottom, 22)
+                        
+                        HStack (alignment: .bottom, spacing: 0){
+                            Spacer()
+                            Text("\(summary.averageSpeed, specifier: "%.f")")
+                                .customFont(.mainNumber)
+                                .offset(y: 37)
+                                .foregroundStyle(.lavenderPurple)
+                            
+                            Text("km/h")
+                                .customFont(.supplementaryTimeDistanceNumber)
+                                .foregroundStyle(.midnightCharcoal)
+                                .opacity(0.5)
+                            
+                        }
+                        .padding(.bottom, -29)
+                        .offset(y: -74)
+                        
+                    }
                     
+                    // MARK: 속도분포
+                    SpeedDistributionView(segments: vm.getSpeedDistribution())
                     
-                    Text("총 주행시간: \(summary.totalRideTime.formatTime())")
-                    Text("총 휴식 시간: \(summary.totalRestTime.formatTime())")
+                    VStack(alignment: .leading, spacing: 0){
+                        Text("총 시간")
+                            .customFont(.infoTitle)
+                            .foregroundStyle(.midnightCharcoal)
+                            .padding(.bottom, 10)
+                        
+                        Text("\(summary.totalTime.formatTime())")
+                            .customFont(.baseTimeDistanceNumber)
+                            .foregroundStyle(.midnightCharcoal)
+                            .padding(.bottom, 24)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        
+                        HStack {
+                            VStack(alignment: .leading, spacing: 0){
+                                Text("주행시간")
+                                    .customFont(.subInfoTitle)
+                                    .foregroundStyle(.midnightCharcoal)
+                                    .padding(.bottom, 8)
+                                Text("\(summary.totalRideTime.formatTime()) ")
+                                    .customFont(.supplementaryTimeDistanceNumber)
+                                    .foregroundStyle(.midnightCharcoal)
+                            }
+                            
+                            VStack(alignment: .leading, spacing: 0){
+                                Text("휴식시간")
+                                    .customFont(.subInfoTitle)
+                                    .foregroundStyle(.midnightCharcoal)
+                                    .padding(.bottom, 8)
+                                Text("\(summary.totalRestTime.formatTime())")
+                                    .customFont(.supplementaryTimeDistanceNumber)
+                                    .foregroundStyle(.midnightCharcoal)
+                            }
+                            .padding(.horizontal, 40)
+                        }
+                        
+                    }
+                    .padding(.vertical, 70)
                     
+                    HStack {
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text("거리")
+                                .customFont(.infoTitle)
+                                .foregroundStyle(.midnightCharcoal)
+                                .padding(.bottom, 10)
+                            Text("\(summary.totalDistance, specifier: "%.2f") km")
+                                .customFont(.baseTimeDistanceNumber)
+                                .foregroundStyle(.midnightCharcoal)
+                        }
+                        
+                        Spacer()
+                    }
                     
-                    Text("평균 속도: \(summary.averageSpeed, specifier: "%.1f") km/h")
-                    
+                } else {
+                    Text("주행 요약 정보를 불러오는 중...")
                 }
                 
-                Text("속도 구간별 주행 시간")
-                    .font(.headline)
-                    .padding(.top)
-                
-                // MARK: 속도분포
-                SpeedDistributionView(segments: vm.getSpeedDistribution())
-               
-                
-            } else {
-                Text("주행 요약 정보를 불러오는 중...")
             }
         }
-        .padding(.horizontal, 30)
+        .padding([.horizontal, .bottom], 30)
         .onAppear {
             vm.getSummary()
         }

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -23,122 +23,141 @@ struct RideSummaryView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            VStack(spacing: 0) {
-                HStack {
-                    ZStack {
-                        Text("라이딩 종료")
+            HStack {
+                ZStack {
+                    Text("라이딩 종료")
+                        .customFont(.pageTitle)
+                    
+                    HStack {
+                        Spacer()
                         
-                        HStack {
-                            Spacer()
-                            
-                            Button {
-                                vm.dismissSummary()
-                            } label: {
-                                Image(systemName: "multiply")
-                            }
+                        Button {
+                            vm.dismissSummary()
+                        } label: {
+                            Image(systemName: "multiply")
+                                .customFont(.pageTitle)
                         }
                     }
                 }
-                .frame(height: 42)
-                .padding(.bottom, 22)
-                
-                if let summary = vm.rideSummary {
-                    HStack {
-                        Text("평균 속도")
-                        Spacer()
-                    }
-                    .padding(.bottom, 22)
-                    
-                    HStack {
-                        Spacer()
-                        Text("\(summary.averageSpeed, specifier: "%.1f")")
-                        Text("km/h")
-                        
-                    }
-                    .padding(.bottom, 45)
-                    
-                    // 속도 구간별 주행 시간
-                    let segments = vm.calculateSpeedDistribution()
-                    
-                    GeometryReader { geometry in
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack(spacing: barSpacing) {
-                                ForEach(0..<segments.count, id: \.self) { index in
-                                    VStack(spacing: 0) {
-                                        RoundedRectangle(cornerRadius: 5)
-                                            .fill(speedColors[index])
-                                            .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio, height: 17)
-                                            .padding(.bottom, 17)
-                                        
-                                        VStack(alignment: .leading, spacing: 0){
-                                            HStack(spacing: 6) {
-                                                Text("\(speedLabels[index])")
-                                                    .customFont(.subInfoTitle)
-                                                Circle()
-                                                    .fill(speedColors[index])
-                                                    .frame(width: 7, height: 7)
-                                            }
-                                            .padding(.bottom, 10)
-                                            
-                                            
-                                            Text("\(vm.formatTime(segments[index].time))")
-                                            //                                            Text("(\(Int(segments[index].ratio * 100))%)")
-                                        }
-                                    }
-                                    
-                                }
-                            }
-                            
-                        }
-                    }
-                    .frame(height: 80)
-                    .padding(.vertical)
-                    
-                    
-                    VStack(alignment: .leading, spacing: 0){
-                        Text("총 시간")
-                            .padding(.bottom, 10)
-                        Text("\(vm.formatTime(summary.totalTime))")
-                            .padding(.bottom, 24)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        
-                        HStack {
-                            VStack(alignment: .leading, spacing: 0){
-                                Text("총 주행시간")
-                                    .padding(.bottom, 8)
-                                Text("\(vm.formatTime(summary.totalRideTime)) ")
-                            }
-                            
-                            VStack(alignment: .leading, spacing: 0){
-                                Text("총 휴식 시간")
-                                    .padding(.bottom, 8)
-                                Text("\(vm.formatTime(summary.totalRestTime))")
-                            }
-                            .padding(.horizontal, 40)
-                        }
-                        
-                    }
-                    .padding(.vertical, 70)
-                    
-                    HStack {
-                        VStack(alignment: .leading, spacing: 0) {
-                            Text("총 거리")
-                                .padding(.bottom, 10)
-                            Text("\(summary.totalDistance, specifier: "%.2f") km")
-                        }
-                        
-                        Spacer()
-                    }
-                    
-                } else {
-                    Text("주행 요약 정보를 불러오는 중...")
-                }
-                
-                Spacer()
             }
-            .frame(maxHeight: .infinity)
+            .frame(height: 42)
+            .background(Color.white)
+            .padding(.bottom, 22)
+            
+            ScrollView {
+                VStack(spacing: 0) {
+                    if let summary = vm.rideSummary {
+                        VStack(spacing: 0) {
+                            HStack {
+                                Text("평균 속도")
+                                    .customFont(.infoTitle)
+                                Spacer()
+                            }
+                            .padding(.bottom, 22)
+                            
+                            HStack (alignment: .bottom, spacing: 0){
+                                Spacer()
+                                Text("\(summary.averageSpeed, specifier: "%.f")")
+                                    .customFont(.mainNumber)
+                                    .offset(y: 37)
+                                
+                                Text("km/h")
+                                    .customFont(.supplementaryTimeDistanceNumber)
+                                
+                            }
+                            .padding(.bottom, -29)
+                            .offset(y: -74)
+                            //                            .padding(.bottom, 45)
+                        }
+                        
+                        // 속도 구간별 주행 시간
+                        let segments = vm.calculateSpeedDistribution()
+                        
+                        GeometryReader { geometry in
+                            VStack(alignment: .leading, spacing: 0) {
+                                HStack(spacing: barSpacing) {
+                                    ForEach(0..<segments.count, id: \.self) { index in
+                                        VStack(spacing: 0) {
+                                            RoundedRectangle(cornerRadius: 5)
+                                                .fill(speedColors[index])
+                                                .frame(width: (geometry.size.width - CGFloat(segments.count - 1) * barSpacing) * segments[index].ratio, height: 17)
+                                                .padding(.bottom, 17)
+                                            
+                                            VStack(alignment: .leading, spacing: 0){
+                                                HStack(spacing: 6) {
+                                                    Text("\(speedLabels[index])")
+                                                        .customFont(.subInfoTitle)
+                                                    Circle()
+                                                        .fill(speedColors[index])
+                                                        .frame(width: 7, height: 7)
+                                                }
+                                                .padding(.bottom, 10)
+                                                
+                                                
+                                                Text("\(vm.formatTime(segments[index].time))")
+                                                    .customFont(.supplementaryTimeDistanceNumber)
+                                                //                                            Text("(\(Int(segments[index].ratio * 100))%)")
+                                            }
+                                        }
+                                        
+                                    }
+                                }
+                                
+                            }
+                        }
+                        .frame(height: 80)
+                        //                        .padding(.vertical)
+                        
+                        VStack(alignment: .leading, spacing: 0){
+                            Text("총 시간")
+                                .customFont(.infoTitle)
+                                .padding(.bottom, 10)
+                            Text("\(vm.formatTime(summary.totalTime))")
+                                .customFont(.baseTimeDistanceNumber)
+                                .padding(.bottom, 24)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            
+                            HStack {
+                                VStack(alignment: .leading, spacing: 0){
+                                    Text("주행시간")
+                                        .customFont(.subInfoTitle)
+                                        .padding(.bottom, 8)
+                                    Text("\(vm.formatTime(summary.totalRideTime)) ")
+                                        .customFont(.supplementaryTimeDistanceNumber)
+                                }
+                                
+                                VStack(alignment: .leading, spacing: 0){
+                                    Text("휴식시간")
+                                        .customFont(.subInfoTitle)
+                                        .padding(.bottom, 8)
+                                    Text("\(vm.formatTime(summary.totalRestTime))")
+                                        .customFont(.supplementaryTimeDistanceNumber)
+                                }
+                                .padding(.horizontal, 40)
+                            }
+                            
+                        }
+                        .padding(.vertical, 70)
+                        
+                        HStack {
+                            VStack(alignment: .leading, spacing: 0) {
+                                Text("거리")
+                                    .customFont(.infoTitle)
+                                    .padding(.bottom, 10)
+                                Text("\(summary.totalDistance, specifier: "%.2f") km")
+                                    .customFont(.baseTimeDistanceNumber)
+                            }
+                            
+                            Spacer()
+                        }
+                        
+                    } else {
+                        Text("주행 요약 정보를 불러오는 중...")
+                    }
+                }
+            }
         }
-        .padding([.horizontal, .bottom], 30)
+        .padding(.horizontal, 30)
         .onAppear {
             vm.getSummary()
         }


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `RideSummaryView`에 여백, 폰트, 색상을 적용했습니다.
- `SpeedDistributionView`에 디자인을 적용했습니다.
- `SpeedDistributionView`의 `contentView` 내부를 수정했습니다.
- `Extension+TimeInterval` 의 시간 단위를 영문으로 수정했습니다.

## 🟠 변경 이유 (Why)
- Hi-Fi 디자인과 최대한 가까운 화면을 구현합니다.
- 코드를 약간 간결하게 만듭니다.

## 🟡 테스트 방법 (How to Test)
1. 앱을 실행하고 주행준비 화면으로 이동
2. 시작버튼을 눌러 주행화면으로 이동
3. 일시정지 버튼을 눌러 휴식화면으로 이동
4. 중지 버튼을 길게 눌러 주행 완료 화면 확인
5. 컴포넌트가 적절히 배치되었는지 확인
7. 다크 모드 전환 시 UI가 적절히 변경되는지 확인

## 🔵 스크린샷 (Visual Proof) (Optional)
<div style="display: flex; justify-content: space-around;">
  <img src="https://github.com/user-attachments/assets/f76b5881-7205-4a0f-9c8f-6b63002e97df" width="30%" />
  <img src="https://github.com/user-attachments/assets/47eebcce-d477-4b03-a231-ff57f1cce028" width="30%" />
</div>

## 🟢 추가 노트 (Additional Notes)
- padding 값 외에 폰트의 내부 여백이 더해져 간격이 벌어진 것을 확인했습니다. 추후 수정 필요.
