### PR TITLE
[feat] 주행 화면 구현

### DIFF
--- a/DomadoV/DomadoV/View/ActiveRideView.swift
+++ b/DomadoV/DomadoV/View/ActiveRideView.swift
@@ -21,71 +21,93 @@ struct ActiveRideView: View {
         ZStack {
             Color.black.edgesIgnoringSafeArea(.all)
             
-            VStack(spacing: 30) {
+            VStack(spacing: 0) {
                 speedometer
+                    .padding(.bottom, 135)
                 
-                HStack(spacing: 20) {
-                    distanceView
-                    Divider().background(Color.white)
-                    timeView
+                HStack(spacing: 0) {
+                    VStack(alignment: .leading, spacing: 45) {
+                        timeView
+                        distanceView
+                        
+                    }
+                    
+                    Spacer()
                 }
                 
-                Spacer()
-                
                 pauseButton
+                    .frame(maxHeight: .infinity, alignment: .bottom)
             }
-            .padding()
+            .frame(maxHeight: .infinity)
+            .padding(.horizontal, 30)
+            .background(Color.indigo)
         }
     }
     
     private var speedometer: some View {
-        VStack {
-            Text("Current Speed")
-                .font(.headline)
-                .foregroundColor(.white)
-            
-            Text(vm.formattedCurrentSpeed())
-                .font(.system(size: 64, weight: .bold, design: .rounded))
-                .foregroundColor(.green)
+        HStack {
+            Spacer()
+            VStack(alignment: .trailing, spacing: 0){
+                Text(vm.formattedCurrentSpeed())
+                    .font(.system(size: 64, weight: .bold, design: .rounded))
+                    .padding(.bottom, 22)
+                    .foregroundColor(.white)
+                
+                Text("현재 속도")
+                    .font(.headline)
+                    .foregroundColor(.white)
+            }
+            .padding(.top, 160)
         }
+    }
+    private var timeView: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("시간")
+                    .font(.subheadline)
+                    .foregroundColor(.white)
+                    .padding(.bottom, 10)
+                
+                Text(vm.formattedTotalRideTime())
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+
+            }
+
     }
     
     private var distanceView: some View {
-        VStack {
-            Text("Distance")
-                .font(.subheadline)
-                .foregroundColor(.white)
-            
-            Text(vm.formattedTotalDistance())
-                .font(.title2)
-                .fontWeight(.semibold)
-                .foregroundColor(.white)
-        }
-    }
-    
-    private var timeView: some View {
-        VStack {
-            Text("Time")
-                .font(.subheadline)
-                .foregroundColor(.white)
-            
-            Text(vm.formattedTotalRideTime())
-                .font(.title2)
-                .fontWeight(.semibold)
-                .foregroundColor(.white)
-        }
+            VStack(alignment: .leading, spacing: 0){
+                Text("거리")
+                    .font(.subheadline)
+                    .foregroundColor(.white)
+                    .padding(.bottom, 10)
+                
+                Text(vm.formattedTotalDistance())
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+            }
+
     }
     
     private var pauseButton: some View {
-        Button(action: {
-            vm.pauseRide()
-        }) {
-            Text("Pause")
-                .font(.headline)
-                .foregroundColor(.black)
-                .padding()
-                .background(Color.yellow)
-                .cornerRadius(10)
+        HStack {
+            Button(action: {
+                vm.pauseRide()
+            }) {
+                Circle()
+                    .stroke(.white,lineWidth: 1)
+                    .frame(width: 104, height: 104)
+                    .overlay(
+                        Image(systemName: "pause.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 35)
+                            .foregroundColor(.white)
+                    )
+            }
+            Spacer()
         }
     }
 }

--- a/DomadoV/DomadoV/View/ActiveRideView.swift
+++ b/DomadoV/DomadoV/View/ActiveRideView.swift
@@ -17,78 +17,87 @@ struct ActiveRideView: View {
     
     @ObservedObject var vm: ActiveRideViewModel
     
+    @Environment(\.colorScheme) private var colorScheme
+    
     var body: some View {
-        ZStack {
-            Color.black.edgesIgnoringSafeArea(.all)
+        VStack(spacing: 0) {
+            speedometer
+                .padding(.bottom, 135)
             
-            VStack(spacing: 0) {
-                speedometer
-                    .padding(.bottom, 135)
-                
-                HStack(spacing: 0) {
-                    VStack(alignment: .leading, spacing: 45) {
-                        timeView
-                        distanceView
-                        
-                    }
-                    
-                    Spacer()
+            
+            HStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 45) {
+                    timeView
+                    distanceView
                 }
-                
-                pauseButton
-                    .frame(maxHeight: .infinity, alignment: .bottom)
+                Spacer()
             }
-            .frame(maxHeight: .infinity)
-            .padding(.horizontal, 30)
-            .background(Color.indigo)
+            .padding(.bottom, 50)
+            
+            pauseButton
         }
+        .padding([.horizontal, .bottom], 30)
+        .background(
+            // 페이스 기준 현재 속도에 따라 색상 변경
+            colorScheme == .dark ? .lavenderPurpleDark : .lavenderPurple
+        )
     }
     
     private var speedometer: some View {
         HStack {
             Spacer()
             VStack(alignment: .trailing, spacing: 0){
-                Text(vm.formattedCurrentSpeed())
-                    .font(.system(size: 64, weight: .bold, design: .rounded))
-                    .padding(.bottom, 22)
-                    .foregroundColor(.white)
+                HStack (alignment: .bottom, spacing: 0){
+                    Text(vm.formattedCurrentSpeed())
+                        .customFont(.mainNumber)
+                        .offset(y: 37)
+                        .foregroundColor(.white)
+                    
+                    Text("km/h")
+                        .customFont(.supplementaryTimeDistanceNumber)
+                        .foregroundColor(.white)
+                }
+                .offset(y: -74)
+                .padding(.bottom, -62)
                 
                 Text("현재 속도")
-                    .font(.headline)
+                    .customFont(.infoTitle)
                     .foregroundColor(.white)
             }
             .padding(.top, 160)
+            
+            
         }
     }
     private var timeView: some View {
-            VStack(alignment: .leading, spacing: 0) {
-                Text("시간")
-                    .font(.subheadline)
-                    .foregroundColor(.white)
-                    .padding(.bottom, 10)
-                
-                Text(vm.formattedTotalRideTime())
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-
-            }
-
+        VStack(alignment: .leading, spacing: 0) {
+            Text("시간")
+                .customFont(.infoTitle)
+                .foregroundColor(.white)
+                .padding(.bottom, 6)
+            
+            Text(vm.formattedTotalRideTime())
+                .customFont(.baseTimeDistanceNumber)
+                .fontWeight(.semibold)
+                .foregroundColor(.white)
+            
+        }
+        
     }
     
     private var distanceView: some View {
-            VStack(alignment: .leading, spacing: 0){
-                Text("거리")
-                    .font(.subheadline)
-                    .foregroundColor(.white)
-                    .padding(.bottom, 10)
-                
-                Text(vm.formattedTotalDistance())
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-            }
-
+        VStack(alignment: .leading, spacing: 0){
+            Text("거리")
+                .customFont(.infoTitle)
+                .foregroundColor(.white)
+                .padding(.bottom, 6)
+            
+            Text(vm.formattedTotalDistance())
+                .customFont(.baseTimeDistanceNumber)
+                .fontWeight(.semibold)
+                .foregroundColor(.white)
+        }
+        
     }
     
     private var pauseButton: some View {

--- a/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
@@ -68,7 +68,7 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
     }
     
     func formattedCurrentSpeed() -> String {
-        return String(format: "%.1f km/h", currentSpeed)
+        return String(format: "%.f", currentSpeed)
     }
     
 }


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `ActiveRideView`에 여백, 폰트, 색상을 적용했습니다.
- `ActiveRideViewModel` 숫자 포맷을 `%.f` 로 변경해 소수점 없이 출력되게 설정했습니다. 

## 🟠 변경 이유 (Why)
- Hi-Fi 디자인과 최대한 가까운 화면을 구현합니다.
- 속도가 표시될 때 `...`으로 나오는 상황을 방지합니다.

## 🟡 테스트 방법 (How to Test)
1. 앱을 실행하고 주행준비 화면으로 이동
2. 시작버튼을 눌러 주행화면 확인
4. 다크 모드 전환 시 UI가 적절히 변경되는지 확인

## 🔵 스크린샷 (Visual Proof) (Optional)
| 라이트 모드 | 다크 모드 |
<div style="display: flex; justify-content: space-around;">
  <img src="https://github.com/user-attachments/assets/f65827b8-53d5-47ec-805f-59e9b10e3caf" width="30%" />
  <img src="https://github.com/user-attachments/assets/49038bfa-cf4e-4a84-9872-951ed3a20054" width="30%" />
</div>

## 🟢 추가 노트 (Additional Notes)
- 다크모드가 적용되었으나, 속도에 따라 색상이 변경되는 부분은 구현되지 않았습니다.
