### PR TITLE
[feat] 휴식 화면 버튼 수정

### DIFF
--- a/DomadoV/DomadoV/View/PauseRideView.swift
+++ b/DomadoV/DomadoV/View/PauseRideView.swift
@@ -111,7 +111,7 @@ struct PauseRideView: View {
                 .frame(width: 40, height: 40)
                 .foregroundColor(isLongPressing ? .white : .gray)
                 .frame(width: 104, height: 104)
-                .background(isLongPressing ? Color.gray : Color.white)
+                .background(isLongPressing ? Color.gray : Color.clear)
                 .clipShape(Circle())
                 .overlay(Circle().stroke(Color.gray, lineWidth: 2))
                 .scaleEffect(isLongPressing ? 0.9 : 1.0)

--- a/DomadoV/DomadoV/View/PauseRideView.swift
+++ b/DomadoV/DomadoV/View/PauseRideView.swift
@@ -22,12 +22,12 @@ struct PauseRideView: View {
     @State private var isLongPressing = false
     
     var body: some View {
-            ZStack {
-                mainContent
-                if showAlert { alertView }
-
-
-            }
+        ZStack {
+            mainContent
+            if showAlert { alertView }
+            
+            
+        }
     }
     
     // MARK: - Main Content
@@ -46,7 +46,7 @@ struct PauseRideView: View {
     // MARK: - Distance Section
     
     private var distanceSection: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 8) {
             HStack {
                 Text("거리")
                     .customFont(.infoTitle)
@@ -62,7 +62,7 @@ struct PauseRideView: View {
     // MARK: - Time Section
     
     private var timeSection: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 8) {
             HStack {
                 Text("시간")                                .customFont(.infoTitle)
                 Spacer()
@@ -76,7 +76,7 @@ struct PauseRideView: View {
     // MARK: - Rest Time Section
     
     private var restTimeSection: some View {
-        VStack(spacing: 17) {
+        VStack(spacing: 15) {
             Text("휴식 시간")
                 .customFont(.infoTitle)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -137,14 +137,19 @@ struct PauseRideView: View {
             vm.resumeRide()
         } label: {
             
-            Image(systemName: "play.fill")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 40, height: 40)
-                .foregroundColor(.white)
-                .frame(width: 104, height: 104)
-                .background(Color.lavenderPurple)
-                .clipShape(Circle())
+            ZStack {
+                Circle()
+                    .fill(Color.lavenderPurple)
+                    .frame(width: 104, height: 104)
+                
+                Image(systemName: "play.fill")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 40, height: 40)
+                    .offset(x: 4, y: 0)
+                    .foregroundColor(.white)
+            }
+            
         }
     }
     
@@ -187,10 +192,10 @@ struct PauseRideView: View {
                 .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
         }
-      
+        
     }
 }
-    
+
 #Preview {
     PauseRideView(vm: PauseRideViewModel(rideSession: RideSession()))
 }


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- 휴식화면 버튼을 수정합니다

## 🟠 변경 이유 (Why)
- 시각보정을 위해 플레이버튼 내부의 아이콘 위치를 조정합니다.
- 중지 버튼 배경을 `clear`로 변경합니다.

## 🔵 스크린샷 (Visual Proof) (Optional)
<img src="https://github.com/user-attachments/assets/b4326cf6-9615-4eac-a82a-d93e76239b90" width = "30%">
