### PR TITLE
[feat] 주행준비 화면 레이아웃

### DIFF
--- a/DomadoV/DomadoV/View/Component/ArcRangeSlider.swift
+++ b/DomadoV/DomadoV/View/Component/ArcRangeSlider.swift
@@ -14,11 +14,11 @@ struct ArcRangeSlider: View {
     private let minimumGap: Double = 10
     private let numberOfMajorTicks: Int = 12 + 1
     private let numberOfMinorTicks: Int = 60
-    private let sliderWidth: CGFloat = 52
-    private let tickLength: CGFloat = 5
-    private let majorTickLength: CGFloat = 15
+    private let sliderWidth: CGFloat = 50
+    private let tickLength: CGFloat = 3.5
+    private let majorTickLength: CGFloat = 10.5
     private let gapBetweenSliderAndTicks: CGFloat = 3
-    private let handleSize: CGFloat = 52
+    private let handleSize: CGFloat = 39
 
     var body: some View {
         GeometryReader { geometry in
@@ -36,7 +36,8 @@ struct ArcRangeSlider: View {
                                 endAngle: .degrees(180),
                                 clockwise: true)
                 }
-                .stroke(Color.gray.opacity(0.3), lineWidth: sliderWidth)
+//                .stroke(Color.gray.opacity(0.3), lineWidth: sliderWidth)
+                .stroke(.midnightCharcoal.opacity(0.1), style: StrokeStyle(lineWidth: sliderWidth, lineCap: .round, lineJoin: .round))
 
                 // Selected range arc
                 Path { path in
@@ -46,7 +47,7 @@ struct ArcRangeSlider: View {
                                 endAngle: Angle(degrees: 180 + (range.upperBound / 60 * 180)),
                                 clockwise: false)
                 }
-                .stroke(.lavenderPurple, lineWidth: sliderWidth)
+                .stroke(.lavenderPurple ,style: StrokeStyle(lineWidth: sliderWidth, lineCap: .round, lineJoin: .round))
 
                 // Minor ticks
                 ForEach(0..<numberOfMinorTicks) { index in
@@ -68,7 +69,7 @@ struct ArcRangeSlider: View {
                     Circle()
                         .fill(Color.white)
                         .frame(width: handleSize, height: handleSize)
-                        .shadow(color:.lavenderPurple, radius: 1)
+                        .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 0)
                     Image(systemName: "bicycle")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -88,7 +89,7 @@ struct ArcRangeSlider: View {
                     Circle()
                         .fill(Color.white)
                         .frame(width: handleSize, height: handleSize)
-                        .shadow(color:.lavenderPurple, radius: 1)
+                        .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 0)
                     Image(systemName: "bicycle")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -104,7 +105,7 @@ struct ArcRangeSlider: View {
                 )
             }
         }
-        .aspectRatio(1, contentMode: .fit)
+        .aspectRatio(2, contentMode: .fit)
         .padding()
     }
 
@@ -124,7 +125,7 @@ struct ArcRangeSlider: View {
             path.move(to: CGPoint(x: innerX, y: innerY))
             path.addLine(to: CGPoint(x: outerX, y: outerY))
         }
-        .stroke(isMajor ? .midnightCharcoal.opacity(0.5) : .midnightCharcoal.opacity(0.3), lineWidth: isMajor ? 2 : 1)
+        .stroke(isMajor ? .midnightCharcoal.opacity(0.3) : .midnightCharcoal.opacity(0.1), lineWidth: isMajor ? 2 : 1)
     }
 
     private func label(for value: Int, in size: CGSize) -> some View {
@@ -137,7 +138,7 @@ struct ArcRangeSlider: View {
         let y = centerY + radius * sin(CGFloat(angle) * .pi / 180)
 
         return Text("\(value)")
-            .font(.caption)
+            .customFont(.paceUnitNumber)
             .foregroundStyle(.midnightCharcoal)
             .position(x: x, y: y)
     }

--- a/DomadoV/DomadoV/View/RidePreparationView.swift
+++ b/DomadoV/DomadoV/View/RidePreparationView.swift
@@ -20,45 +20,99 @@ struct RidePreparationView: View {
     
     var body: some View {
         
-        VStack(spacing: 20){
-            
-            Map(position: $position) {
-                UserAnnotation()
+        ZStack {
+            VStack(spacing: 0){
+                // 지도 표시
+                Map(position: $position) {
+                    UserAnnotation()
+                }
+                .mapStyle(.standard)
+                .edgesIgnoringSafeArea(.all)
+                .frame(height: 400)
+                
+                Spacer()
             }
-            .mapStyle(.standard)
-            .edgesIgnoringSafeArea(.all)
-            .frame(height: 300)
-            
-            Text("주행 속도 범위 입력받는 arc 모양 Slider")
-            
-            Button {
-                vm.startRide()
-            } label: {
-                Text("시작 버튼")
+            GeometryReader { geometry in
+                VStack(spacing: 0){
+                    // 운동 기록 버튼
+                    HStack {
+                        Spacer()
+                        
+                        Button {
+                            vm.showHistory()
+                        } label: {
+                            Text("운동 기록")
+                                .foregroundStyle(.lavenderPurple)
+                        }
+                    }
+                    
+                    // 페이스 설정
+                    VStack(spacing: 0){
+                        Text("페이스 설정")
+                            .customFont(.pageTitle)
+                            .padding(.top, 28)
+                        
+                        HStack (spacing: 20){
+                            Text("\(vm.userSettingTargetSpeedRange.lowerBound.formatToDecimal(0))")
+                                .customFont(.paceSettingNumber)
+                                .frame(width: 70, alignment: .trailing)
+                            Text("-")
+                                .customFont(.supplementaryTimeDistanceNumber)
+                                .opacity(0.3)
+                            Text("\(vm.userSettingTargetSpeedRange.upperBound.formatToDecimal(0))")
+                                .customFont(.paceSettingNumber)
+                                .frame(width: 70, alignment: .leading)
+                            Text("km/h")
+                                .customFont(.supplementaryTimeDistanceNumber)
+                                .opacity(0.3)
+                                .offset(y:10)
+                        }
+                        .frame(width: 350)
+                        .padding(.bottom, 28)
+                        
+                    }
+                    
+                    // 양방향 슬라이더
+                    ArcRangeSlider(range: $vm.userSettingTargetSpeedRange)
+                        .frame(width: 300, height: 200)
+                        .padding(.bottom, 10)
+                    
+                    // 라이딩 시작 버튼
+                    Button {
+                        vm.startRide()
+                    } label: {
+                        ZStack{
+                            Circle()
+                                .frame(width: 145, height: 145)
+                                .foregroundStyle(.lavenderPurple)
+                            Text("라이딩 시작")
+                                .foregroundColor(.white)
+                        }
+                    }
+                    
+                }
+                .padding(30)
+                .background(Color(.systemBackground))
+                .cornerRadius(35)
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: -1)
+                .frame(width: geometry.size.width, height: geometry.size.height, alignment: .bottom)
             }
-            
-            Button {
-                vm.showHistory()
-            } label: {
-                Text("주행 기록 보기 버튼")
+            .edgesIgnoringSafeArea(.bottom)
+            .onAppear {
+                vm.prepareRide()
             }
-            
-            Spacer()
-            
+            .alert(isPresented: $vm.showLocationPermissionAlert) {
+                Alert(
+                    title: Text("위치 권한 필요"),
+                    message: Text("이 앱은 위치 정보를 사용하여 주행을 기록합니다. 설정에서 위치 권한을 허용해주세요."),
+                    primaryButton: .default(Text("설정으로 이동")) {
+                        vm.openSystemSettings()
+                    },
+                    secondaryButton: .cancel(Text("취소"))
+                )
+            }
         }
-        .onAppear {
-            vm.prepareRide()
-        }
-        .alert(isPresented: $vm.showLocationPermissionAlert) {
-            Alert(
-                title: Text("위치 권한 필요"),
-                message: Text("이 앱은 위치 정보를 사용하여 주행을 기록합니다. 설정에서 위치 권한을 허용해주세요."),
-                primaryButton: .default(Text("설정으로 이동")) {
-                    vm.openSystemSettings()
-                },
-                secondaryButton: .cancel(Text("취소"))
-            )
-        }
+        
     }
 }
 

--- a/DomadoV/DomadoV/View/RideSummaryView.swift
+++ b/DomadoV/DomadoV/View/RideSummaryView.swift
@@ -31,7 +31,7 @@ struct RideSummaryView: View {
                         Button {
                             vm.dismissSummary()
                         } label: {
-                            Image(systemName: "multiply")
+                            Image(systemName: "xmark")
                                 .frame(width: 16, height: 16)
                                 .foregroundColor(.midnightCharcoal)
                                 .opacity(0.3)


### PR DESCRIPTION
## 🔴 변경 사항 (What)
- `RidePreparationView`에 디자인과 여백을 적절히 적용하였습니다.
- `ActiveRideView`의 디자인을 변경하였습니다.
- `RideSummaryView`에 버튼 이미지를 변경하였습니다.

## 🟠 변경 이유 (Why)
- Hi-Fi 디자인과 최대한 가까운 화면을 구현합니다.
- 다양한 기기에 호환될 수 있도록 여백을 조정했습니다.

## 🟡 테스트 방법 (How to Test)
1. 앱을 실행하고 주행준비 화면으로 이동
2. 다크 모드 전환 시 UI가 적절히 변경되는지 확인

## 🔵 스크린샷 (Visual Proof) (Optional)
<div style="display: flex; justify-content: space-around;">
 <img src="https://github.com/user-attachments/assets/ef110358-b701-4563-bdfc-0bd26ca1aef3" width="30%" />
 <img src="https://github.com/user-attachments/assets/ad724a14-15d7-4e42-ac2d-e7e3841c4eeb" width="30%" />
</div>

## 🟢 추가 노트 (Additional Notes)
