### PR TITLE
[feat] 주행 화면 배경 색상 변경 적용

### DIFF
--- a/DomadoV/DomadoV/View/ActiveRideView.swift
+++ b/DomadoV/DomadoV/View/ActiveRideView.swift
@@ -39,7 +39,7 @@ struct ActiveRideView: View {
         .padding([.horizontal, .bottom], 30)
         .background(
             // 페이스 기준 현재 속도에 따라 색상 변경
-            colorScheme == .dark ? .lavenderPurpleDark : .lavenderPurple
+            colorScheme == .dark ? vm.backgroundColorDark : vm.backgroundColor
         )
     }
     

--- a/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
@@ -31,7 +31,7 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
         setupSubscriptions()
         
         self.targetSpeedRange = rideSession.targetSpeedRange
-        changeBackground()
+//        changeBackground()
     }
     
     private func setupSubscriptions() {
@@ -56,6 +56,8 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newSpeed in
                 self?.currentSpeed = newSpeed
+                //  이곳에서 해당 메서드를 호출해야합니다. 🦖
+                self?.changeBackground()
             }
             .store(in: &cancellables)
     }

--- a/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import SwiftUI
 
 /// 주행화면에 대한 정보와 동작을 관리합니다. 
 class ActiveRideViewModel: ObservableObject, RideEventPublishable {
@@ -14,6 +15,11 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
     @Published var totalRideTime: TimeInterval = 0
     @Published var totalDistance: Double = 0
     @Published var currentSpeed: Double = 0
+        
+    @Published var backgroundColor: Color = .lavenderPurple
+    @Published var backgroundColorDark: Color = .lavenderPurpleDark
+    
+    var targetSpeedRange: ClosedRange<Double> = 0...15
     
     var rideSession: RideSession
     /// AppCoordinator에게 RideEvent를 발행하여 화면을 전환합니다.
@@ -23,6 +29,9 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
     init(rideSession: RideSession) {
         self.rideSession = rideSession
         setupSubscriptions()
+        
+        self.targetSpeedRange = rideSession.targetSpeedRange
+        changeBackground()
     }
     
     private func setupSubscriptions() {
@@ -71,4 +80,17 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
         return String(format: "%.f", currentSpeed)
     }
     
+
+    func changeBackground() {
+        if currentSpeed < targetSpeedRange.lowerBound {
+            backgroundColor = .electricBlue
+            backgroundColorDark = .electricBlueDark
+        } else if currentSpeed > targetSpeedRange.upperBound {
+            backgroundColor = .lavenderPurple
+            backgroundColorDark = .lavenderPurpleDark
+        } else {
+            backgroundColor = .sunsetOrange
+            backgroundColorDark = .sunsetOrangeDark
+        }
+    }
 }

--- a/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
@@ -86,11 +86,11 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
             backgroundColor = .electricBlue
             backgroundColorDark = .electricBlueDark
         } else if currentSpeed > targetSpeedRange.upperBound {
-            backgroundColor = .lavenderPurple
-            backgroundColorDark = .lavenderPurpleDark
-        } else {
             backgroundColor = .sunsetOrange
             backgroundColorDark = .sunsetOrangeDark
+        } else {
+            backgroundColor = .lavenderPurple
+            backgroundColorDark = .lavenderPurpleDark
         }
     }
 }

--- a/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
+++ b/DomadoV/DomadoV/ViewModel/ActiveRideViewModel.swift
@@ -31,7 +31,6 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
         setupSubscriptions()
         
         self.targetSpeedRange = rideSession.targetSpeedRange
-//        changeBackground()
     }
     
     private func setupSubscriptions() {
@@ -56,7 +55,6 @@ class ActiveRideViewModel: ObservableObject, RideEventPublishable {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newSpeed in
                 self?.currentSpeed = newSpeed
-                //  이곳에서 해당 메서드를 호출해야합니다. 🦖
                 self?.changeBackground()
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## 🔴 변경 사항 (What)
 - `ActiveRideViewModel`에  `targetSpeedRange`를 프로퍼티로 추가하였습니다. 이 프로퍼티는 현재 속도(`currentSpeed`)가 변화할 때마다 속도 범위를 비교하기 위해 사용됩니다.
 - `rideSession`에 있는 목표 속도 범위(`targetSpeedRange`)를 가져와 `targetSpeedRange` 프로퍼티에 할당해 초기화해줍니다.
- `ActiveRideViewModel`에 `backgroundColor` 프로퍼티를 추가하고 `@Published`속성을 붙여, 값이 변할 때마다 주행 화면에 반영되도록 합니다.
- `currentSpeed`가 변경될 때 마다 `changeBackground()`를 호출하여 배경 색상을 업데이트합니다. 
- `changeBackground()` 에서는 `currentSpeed`와 `targetSpeedRange`를 비교해서 `backgroundColor`를 변경하는 로직을 구현하였습니다. 이를 통해 주행 중 목표 속도 범위에 들어와있는지 여부를 시각적으로 나타낼 수 있습니다.

## 🟠 변경 이유 (Why)
사용자가 설정한 속도범위를 기준으로 현재 속도 상태를 배경색으로 보여줍니다.

## 🟡 테스트 방법 (How to Test)
1. 앱을 실행하고 주행준비화면으로 이동
2. 속도 범위 설정 후, 라이딩 시작 버튼을 눌러 **주행 화면**으로 이동
4. 설정한 속도 범위를 기준으로 배경색이 적절히 변화되는지 확인
5. 다크 모드 전환 시 UI가 적절히 변경되는지 확인

## 🔵 스크린샷 (Visual Proof) (Optional)
<div style="display: flex; justify-content: space-around;">
<img src="https://github.com/user-attachments/assets/c3593cd7-1012-42e6-985a-fd635cc7fb1e" width="30%" />
<img src="https://github.com/user-attachments/assets/5d862e71-6f3b-4a4f-a92a-35dc3c0d9337" width="30%" />
</div>

## 🟢 추가 노트 (Additional Notes)
- 다크모드를 위해 backgroundColor 프로퍼티를 두가지로 만들었는데 적절한건지 모르겠어요.
- 테스트를 위해 앱을 실행하는데 움직이지 않아도 속도가 5-7 까지 올라가더라구요, 뭔가 잘못된 것일까요?
